### PR TITLE
fix example site.cfg for extending docker image

### DIFF
--- a/docs/usage.rst
+++ b/docs/usage.rst
@@ -130,8 +130,6 @@ site.cfg
 
   [buildout]
   extends = buildout.cfg
-
-  [instance]
   eggs += plone.awsome.addon
 
 Dockerfile


### PR DESCRIPTION
without this change plone would not be installed and a plain zope instance would be started