### PR TITLE
Adding LABEL Env. with Plone versions

### DIFF
--- a/4.3/4.3.11/alpine/Dockerfile
+++ b/4.3/4.3.11/alpine/Dockerfile
@@ -1,6 +1,8 @@
 FROM python:2.7-alpine
 MAINTAINER "Plone Community" http://community.plone.org
 
+LABEL plone.version="4.3.11"
+
 RUN addgroup -g 500 plone \
  && adduser -S -D -G plone -u 500 plone \
  && mkdir -p /plone /data/filestorage /data/blobstorage \

--- a/4.3/4.3.11/debian/Dockerfile
+++ b/4.3/4.3.11/debian/Dockerfile
@@ -1,6 +1,8 @@
 FROM python:2.7-slim
 MAINTAINER "Plone Community" http://community.plone.org
 
+LABEL plone.version="4.3.11"
+
 RUN useradd --system -U -u 500 plone \
  && mkdir -p /plone /data/filestorage /data/blobstorage \
  && chown -R plone:plone /plone /data

--- a/5.0/5.0.6/alpine/Dockerfile
+++ b/5.0/5.0.6/alpine/Dockerfile
@@ -1,6 +1,8 @@
 FROM python:2.7-alpine
 MAINTAINER "Plone Community" http://community.plone.org
 
+LABEL plone.version="5.0.6"
+
 RUN addgroup -g 500 plone \
  && adduser -S -D -G plone -u 500 plone \
  && mkdir -p /plone /data/filestorage /data/blobstorage \

--- a/5.0/5.0.6/debian/Dockerfile
+++ b/5.0/5.0.6/debian/Dockerfile
@@ -1,6 +1,8 @@
 FROM python:2.7-slim
 MAINTAINER "Plone Community" http://community.plone.org
 
+LABEL plone.version="5.0.6"
+
 RUN useradd --system -U -u 500 plone \
  && mkdir -p /plone /data/filestorage /data/blobstorage \
  && chown -R plone:plone /plone /data


### PR DESCRIPTION
This adds to the latest 5 and 4.3 Dockerfiles the LABEL environment variable with the responding version of Plone, by doing so you will be able to get the Plone version with docker inspect as LABEL. 