### PR TITLE
Add: Label for OS, get Plone Label from ENV setting

### DIFF
--- a/4.3/4.3.11/alpine/Dockerfile
+++ b/4.3/4.3.11/alpine/Dockerfile
@@ -1,8 +1,6 @@
 FROM python:2.7-alpine
 MAINTAINER "Plone Community" http://community.plone.org
 
-LABEL plone.version="4.3.11"
-
 RUN addgroup -g 500 plone \
  && adduser -S -D -G plone -u 500 plone \
  && mkdir -p /plone /data/filestorage /data/blobstorage \
@@ -11,6 +9,9 @@ RUN addgroup -g 500 plone \
 ENV PLONE_MAJOR=4.3
 ENV PLONE_VERSION=4.3.11
 ENV PLONE_MD5=207cdf096869d11cee69339e95ace496
+
+LABEL plone.version=$PLONE_VERSION
+LABEL os="alpine" os.version="3.4"
 
 RUN apk add --no-cache --virtual .build-deps \
     curl \

--- a/4.3/4.3.11/debian/Dockerfile
+++ b/4.3/4.3.11/debian/Dockerfile
@@ -1,8 +1,6 @@
 FROM python:2.7-slim
 MAINTAINER "Plone Community" http://community.plone.org
 
-LABEL plone.version="4.3.11"
-
 RUN useradd --system -U -u 500 plone \
  && mkdir -p /plone /data/filestorage /data/blobstorage \
  && chown -R plone:plone /plone /data
@@ -10,6 +8,9 @@ RUN useradd --system -U -u 500 plone \
 ENV PLONE_MAJOR=4.3
 ENV PLONE_VERSION=4.3.11
 ENV PLONE_MD5=207cdf096869d11cee69339e95ace496
+
+LABEL plone.version=$PLONE_VERSION
+LABEL os="debian" os.version="8"
 
 RUN buildDeps="curl sudo python-setuptools python-dev build-essential libssl-dev libxml2-dev libxslt1-dev libbz2-dev libjpeg62-turbo-dev" \
  && runDeps="libxml2 libxslt1.1 libjpeg62 rsync" \

--- a/5.0/5.0.6/alpine/Dockerfile
+++ b/5.0/5.0.6/alpine/Dockerfile
@@ -1,8 +1,6 @@
 FROM python:2.7-alpine
 MAINTAINER "Plone Community" http://community.plone.org
 
-LABEL plone.version="5.0.6"
-
 RUN addgroup -g 500 plone \
  && adduser -S -D -G plone -u 500 plone \
  && mkdir -p /plone /data/filestorage /data/blobstorage \
@@ -11,6 +9,9 @@ RUN addgroup -g 500 plone \
 ENV PLONE_MAJOR=5.0
 ENV PLONE_VERSION=5.0.6
 ENV PLONE_MD5=c6951b0f79be1bf12337d49f34afc524
+
+LABEL plone.version=$PLONE_VERSION
+LABEL os="alpine" os.version="3.4"
 
 RUN apk add --no-cache --virtual .build-deps \
     curl \

--- a/5.0/5.0.6/debian/Dockerfile
+++ b/5.0/5.0.6/debian/Dockerfile
@@ -1,8 +1,6 @@
 FROM python:2.7-slim
 MAINTAINER "Plone Community" http://community.plone.org
 
-LABEL plone.version="5.0.6"
-
 RUN useradd --system -U -u 500 plone \
  && mkdir -p /plone /data/filestorage /data/blobstorage \
  && chown -R plone:plone /plone /data
@@ -10,6 +8,10 @@ RUN useradd --system -U -u 500 plone \
 ENV PLONE_MAJOR=5.0
 ENV PLONE_VERSION=5.0.6
 ENV PLONE_MD5=c6951b0f79be1bf12337d49f34afc524
+
+LABEL plone.version=$PLONE_VERSION
+LABEL os="debian" os.version="8"
+
 
 RUN buildDeps="curl sudo python-setuptools python-dev build-essential libssl-dev libxml2-dev libxslt1-dev libbz2-dev libjpeg62-turbo-dev" \
  && runDeps="libxml2 libxslt1.1 libjpeg62 rsync" \


### PR DESCRIPTION
- This pull request adds a Label for the container OS and its version.
- It get the plone.version label now from ENV PLONE_VERSION=5.0.6, which makes it less work for us

@avoinea please review if you have a moment :)