### PR TITLE
Follow best practices

### DIFF
--- a/5.0/5.0.7/debian/Dockerfile
+++ b/5.0/5.0.7/debian/Dockerfile
@@ -12,7 +12,7 @@ ENV PLONE_MD5=347e787d10a6a02d8156ed8c05effcdb
 LABEL plone=$PLONE_VERSION \
 	  os="debian" \
 	  os.version="8" \
-	  name="Plone5 " \
+	  name="Plone 5" \
 	  description="Plone image, based on Unified Installer" \
 	  maintainer="Plone Community"
 

--- a/5.0/5.0.7/debian/Dockerfile
+++ b/5.0/5.0.7/debian/Dockerfile
@@ -9,11 +9,12 @@ ENV PLONE_MAJOR=5.0
 ENV PLONE_VERSION=5.0.7
 ENV PLONE_MD5=347e787d10a6a02d8156ed8c05effcdb
 
-LABEL version=$PLONE_VERSION \
+LABEL plone=$PLONE_VERSION \
 	  os="debian" \
 	  os.version="8" \
-	  name="plone"
-
+	  name="Plone 5 " \
+	  description="Plone image, based on Unified Installer" \
+	  maintainer="Plone Community"
 
 RUN buildDeps="curl sudo python-setuptools python-dev build-essential libssl-dev libxml2-dev libxslt1-dev libbz2-dev libjpeg62-turbo-dev" \
  && runDeps="libxml2 libxslt1.1 libjpeg62 rsync" \

--- a/5.0/5.0.7/debian/Dockerfile
+++ b/5.0/5.0.7/debian/Dockerfile
@@ -12,7 +12,7 @@ ENV PLONE_MD5=347e787d10a6a02d8156ed8c05effcdb
 LABEL plone=$PLONE_VERSION \
 	  os="debian" \
 	  os.version="8" \
-	  name="Plone 5 " \
+	  name="Plone5 " \
 	  description="Plone image, based on Unified Installer" \
 	  maintainer="Plone Community"
 

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,5 +1,6 @@
 CHANGELOG
 ---------
 
+- Adjust Label settings to follow best practices
 - Add (apt-mark showauto), Jenkins shut up
   [svx]


### PR DESCRIPTION
This PR removes the old and deprecated 'MAINTAINER' setting.

In place of this we follow current best practice, according to: https://docs.docker.com/engine/reference/builder/#maintainer-deprecated.

Further the LABEL settings got updated

![plone-docker-label](https://cloud.githubusercontent.com/assets/358860/24755335/0cd18f1e-1ada-11e7-99f1-9a0bc42012b4.png)
