### PR TITLE
Add missing Pillow dependencies to support openjpg and tiff scaling.

### DIFF
--- a/4.3/4.3.12/debian/Dockerfile
+++ b/4.3/4.3.12/debian/Dockerfile
@@ -1,9 +1,9 @@
 FROM python:2.7-slim
 MAINTAINER "Plone Community" http://community.plone.org
 
-RUN useradd --system -m -d /plone -U -u 500 plone \
- && mkdir -p /data/filestorage /data/blobstorage \
- && chown -R plone:plone /data
+RUN useradd --system -U -u 500 plone \
+ && mkdir -p /plone /data/filestorage /data/blobstorage \
+ && chown -R plone:plone /plone /data
 
 ENV PLONE_MAJOR=4.3
 ENV PLONE_VERSION=4.3.12

--- a/4.3/4.3.12/debian/Dockerfile
+++ b/4.3/4.3.12/debian/Dockerfile
@@ -12,7 +12,7 @@ ENV PLONE_MD5=62291e00e1b86b8794772e6841a29570
 LABEL plone.version=$PLONE_VERSION
 LABEL os="debian" os.version="8"
 
-RUN buildDeps="curl sudo python-setuptools python-dev build-essential libssl-dev libxml2-dev libxslt1-dev libbz2-dev libjpeg62-turbo-dev" \
+RUN buildDeps="curl sudo python-setuptools python-dev build-essential libssl-dev libxml2-dev libxslt1-dev libbz2-dev libjpeg62-turbo-dev libtiff5-dev libopenjp2-7-dev" \
  && runDeps="libxml2 libxslt1.1 libjpeg62 rsync lynx wv libtiff5 libopenjp2-7 poppler-utils" \
  && apt-get update \
  && apt-get install -y --no-install-recommends $buildDeps \

--- a/4.3/4.3.12/debian/Dockerfile
+++ b/4.3/4.3.12/debian/Dockerfile
@@ -13,7 +13,7 @@ LABEL plone.version=$PLONE_VERSION
 LABEL os="debian" os.version="8"
 
 RUN buildDeps="curl sudo python-setuptools python-dev build-essential libssl-dev libxml2-dev libxslt1-dev libbz2-dev libjpeg62-turbo-dev" \
- && runDeps="libxml2 libxslt1.1 libjpeg62 rsync" \
+ && runDeps="libxml2 libxslt1.1 libjpeg62 rsync lynx wv libtiff5 libopenjp2-7 poppler-utils" \
  && apt-get update \
  && apt-get install -y --no-install-recommends $buildDeps \
  && curl -o Plone.tgz -SL https://launchpad.net/plone/$PLONE_MAJOR/$PLONE_VERSION/+download/Plone-$PLONE_VERSION-UnifiedInstaller.tgz \

--- a/5.0/5.0.7/debian/Dockerfile
+++ b/5.0/5.0.7/debian/Dockerfile
@@ -9,14 +9,14 @@ ENV PLONE_VERSION=5.0.7
 ENV PLONE_MD5=347e787d10a6a02d8156ed8c05effcdb
 
 LABEL plone=$PLONE_VERSION \
-	  os="debian" \
-	  os.version="8" \
-	  name="Plone 5" \
-	  description="Plone image, based on Unified Installer" \
-	  maintainer="Plone Community"
+    os="debian" \
+    os.version="8" \
+    name="Plone 5" \
+    description="Plone image, based on Unified Installer" \
+    maintainer="Plone Community"
 
-RUN buildDeps="curl sudo python-setuptools python-dev build-essential libssl-dev libxml2-dev libxslt1-dev libbz2-dev libjpeg62-turbo-dev" \
- && runDeps="libxml2 libxslt1.1 libjpeg62 rsync" \
+RUN buildDeps="curl sudo python-setuptools python-dev build-essential libssl-dev libxml2-dev libxslt1-dev libbz2-dev libjpeg62-turbo-dev libtiff5-dev libopenjp2-7-dev" \
+ && runDeps="libxml2 libxslt1.1 libjpeg62 rsync lynx wv libtiff5 libopenjp2-7 poppler-utils" \
  && apt-get update \
  && apt-get install -y --no-install-recommends $buildDeps \
  && curl -o Plone.tgz -SL https://launchpad.net/plone/$PLONE_MAJOR/$PLONE_VERSION/+download/Plone-$PLONE_VERSION-UnifiedInstaller.tgz \

--- a/5.0/5.0.7/debian/Dockerfile
+++ b/5.0/5.0.7/debian/Dockerfile
@@ -1,8 +1,8 @@
 FROM python:2.7-slim
 
-RUN useradd --system -m -d /plone -U -u 500 plone \
- && mkdir -p /data/filestorage /data/blobstorage \
- && chown -R plone:plone /data
+RUN useradd --system -U -u 500 plone \
+ && mkdir -p /plone /data/filestorage /data/blobstorage \
+ && chown -R plone:plone /plone /data
 
 ENV PLONE_MAJOR=5.0
 ENV PLONE_VERSION=5.0.7

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,7 @@
 CHANGELOG
 ---------
 
-- Add -d /home to adduser to correctly set the home dir.
+- Add missing dependencies for pillow and transforms.
   [jladage]
 
 - Remove deprecated maintainer setting


### PR DESCRIPTION
Currently tiff or openjpeg images are not scaled by Pillow because of missing dependencies.

Also add lynx, wv and poppler-utils are needed to support transforms to text used for catalog indexing. When uploading a pdf or oldfashion .doc file of pdf the contents of those files is not added to the SearchableText index because poppler-utils and wc are missing.

Lynx is used to by a legacy transform from html to text which might still be used by add-ons. Although the lynx_dump transform should be removed, as long as that's not the case lynx should be available since it will break the transform.



