### PR TITLE
Add -m -d /home options to useradd command to create home folder

### DIFF
--- a/4.3/4.3.12/debian/Dockerfile
+++ b/4.3/4.3.12/debian/Dockerfile
@@ -1,9 +1,9 @@
 FROM python:2.7-slim
 MAINTAINER "Plone Community" http://community.plone.org
 
-RUN useradd --system -U -u 500 plone \
- && mkdir -p /plone /data/filestorage /data/blobstorage \
- && chown -R plone:plone /plone /data
+RUN useradd --system -m -d /plone -U -u 500 plone \
+ && mkdir -p /data/filestorage /data/blobstorage \
+ && chown -R plone:plone /data
 
 ENV PLONE_MAJOR=4.3
 ENV PLONE_VERSION=4.3.12

--- a/5.0/5.0.7/debian/Dockerfile
+++ b/5.0/5.0.7/debian/Dockerfile
@@ -1,8 +1,8 @@
 FROM python:2.7-slim
 
-RUN useradd --system -U -u 500 -d plone plone \
- && mkdir -p /plone /data/filestorage /data/blobstorage \
- && chown -R plone:plone /plone /data
+RUN useradd --system -m -d /plone -U -u 500 plone \
+ && mkdir -p /data/filestorage /data/blobstorage \
+ && chown -R plone:plone /data
 
 ENV PLONE_MAJOR=5.0
 ENV PLONE_VERSION=5.0.7

--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -1,7 +1,7 @@
 CHANGELOG
 ---------
 
-- Add -d /home to adduser to correctly set the home dir.
+- Add -m option to useradd command to correctly set the home dir.
   [jladage]
 
 - Remove deprecated maintainer setting


### PR DESCRIPTION
@avoinea setting the home folder is needed if you use this container for development and rely on e.g. webpack to build your frontend. It want's to write a config to the home folder which fails. I now added -m -d /plone build and tested the container, so this should be fine to merge now.