### PR TITLE
Replace curl with wget, remove apt-mark showauto for Plone 5

### DIFF
--- a/5.0/5.0.7/debian/Dockerfile
+++ b/5.0/5.0.7/debian/Dockerfile
@@ -15,11 +15,11 @@ LABEL plone=$PLONE_VERSION \
     description="Plone image, based on Unified Installer" \
     maintainer="Plone Community"
 
-RUN buildDeps="curl sudo python-setuptools python-dev build-essential libssl-dev libxml2-dev libxslt1-dev libbz2-dev libjpeg62-turbo-dev libtiff5-dev libopenjp2-7-dev" \
+RUN buildDeps="wget sudo python-setuptools python-dev build-essential libssl-dev libxml2-dev libxslt1-dev libbz2-dev libjpeg62-turbo-dev libtiff5-dev libopenjp2-7-dev" \
  && runDeps="libxml2 libxslt1.1 libjpeg62 rsync lynx wv libtiff5 libopenjp2-7 poppler-utils" \
  && apt-get update \
  && apt-get install -y --no-install-recommends $buildDeps \
- && curl -o Plone.tgz -SL https://launchpad.net/plone/$PLONE_MAJOR/$PLONE_VERSION/+download/Plone-$PLONE_VERSION-UnifiedInstaller.tgz \
+ && wget -O Plone.tgz https://launchpad.net/plone/$PLONE_MAJOR/$PLONE_VERSION/+download/Plone-$PLONE_VERSION-UnifiedInstaller.tgz \
  && echo "$PLONE_MD5 Plone.tgz" | md5sum -c - \
  && tar -xzf Plone.tgz \
  && ./Plone-$PLONE_VERSION-UnifiedInstaller/install.sh \
@@ -37,7 +37,7 @@ RUN buildDeps="curl sudo python-setuptools python-dev build-essential libssl-dev
  && sudo -u plone bin/buildout \
  && chown -R plone:plone /plone /data \
  && rm -rf /Plone* \
- && SUDO_FORCE_REMOVE=yes apt-get remove --purge -y $buildDeps $(apt-mark showauto) \
+ && SUDO_FORCE_REMOVE=yes apt-get remove --purge -y $buildDeps\
  && apt-get install -y --no-install-recommends $runDeps \
  && apt-get clean \
  && rm -rf /var/lib/apt/lists/* \

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,8 @@
 # Changelog
 
-- Switch from `curl` to `wget`, because `wget` has less dependencies than `curl` for Plone 4 and 5.
+- Switch from `curl` to `wget`, because `wget` has less dependencies than `curl` for Plone 5.
+  [svx]
+- Switch from `curl` to `wget`, because `wget` has less dependencies than `curl` for Plone 4.
   [svx]
 - Remove `apt-clean`, not needed because of https://github.com/moby/moby/blob/e925820bfd5af066497800a02c597d6846988398/contrib/mkimage/debootstrap#L107-L130
   [svx]

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,6 +1,6 @@
 # Changelog
 
-- Switch from `curl` to `wget`, becaue `wget` has less dependecies than `curl`
+- Switch from `curl` to `wget`, because `wget` has less dependencies than `curl` for Plone 4 and 5.
   [svx]
 - Remove `apt-clean`, not needed because of https://github.com/moby/moby/blob/e925820bfd5af066497800a02c597d6846988398/contrib/mkimage/debootstrap#L107-L130
   [svx]


### PR DESCRIPTION
This PR does the following:

- Replaces ``curl`` with ``wget``, since ``wget`` has less dependencies
- Removes apt-mark showauto