### PR TITLE
docker: Use explicit OS versions

### DIFF
--- a/5.1/5.1.0/alpine/Dockerfile
+++ b/5.1/5.1.0/alpine/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7-alpine
+FROM python:2.7-alpine3.7
 
 RUN addgroup -g 500 plone \
  && adduser -S -D -G plone -u 500 plone \
@@ -11,7 +11,7 @@ ENV PLONE_MD5=76dc6cfc1c749d763c32fff3a9870d8d
 
 LABEL plone=$PLONE_VERSION \
     os="alpine" \
-    os.version="3.4" \
+    os.version="3.7" \
     name="Plone 5.1" \
     description="Plone image, based on Unified Installer" \
     maintainer="Plone Community"

--- a/5.1/5.1.0/debian/Dockerfile
+++ b/5.1/5.1.0/debian/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:2.7-slim
+FROM python:2.7-slim-stretch
 
 RUN useradd --system -m -d /plone -U -u 500 plone \
  && mkdir -p /data/filestorage /data/blobstorage \
@@ -10,7 +10,7 @@ ENV PLONE_MD5=76dc6cfc1c749d763c32fff3a9870d8d
 
 LABEL plone=$PLONE_VERSION \
     os="debian" \
-    os.version="8" \
+    os.version="9" \
     name="Plone 5.1" \
     description="Plone image, based on Unified Installer" \
     maintainer="Plone Community"


### PR DESCRIPTION
This PR add explicit OS versions.

See it as what you know as version pinning in buildouts :)

By doing so we have more control about the OS versions of the container images itself and it is easier to keep the ``LABEL`` version up to date. 