### PR TITLE
Add support for arm64v8 architecture.

### DIFF
--- a/4.3/4.3.17/debian/Dockerfile
+++ b/4.3/4.3.17/debian/Dockerfile
@@ -19,7 +19,7 @@ RUN useradd --system -m -d /plone -U -u 500 plone \
 
 COPY buildout.cfg /plone/instance/
 
-RUN buildDeps="wget gcc libc6-dev libpcre3-dev libssl-dev libxml2-dev libxslt1-dev libbz2-dev libjpeg62-turbo-dev libtiff5-dev libopenjp2-7-dev zlib1g-dev" \
+RUN buildDeps="build-essential wget gcc libc6-dev libpcre3-dev libssl-dev libxml2-dev libxslt1-dev libbz2-dev libjpeg62-turbo-dev libtiff5-dev libopenjp2-7-dev zlib1g-dev" \
  && runDeps="gosu poppler-utils wv rsync lynx netcat libxml2 libxslt1.1 libjpeg62 libtiff5 libopenjp2-7" \
  && apt-get update \
  && apt-get install -y --no-install-recommends $buildDeps \

--- a/5.1/5.1.2/debian/Dockerfile
+++ b/5.1/5.1.2/debian/Dockerfile
@@ -19,7 +19,7 @@ RUN useradd --system -m -d /plone -U -u 500 plone \
 
 COPY buildout.cfg /plone/instance/
 
-RUN buildDeps="wget gcc libc6-dev libpcre3-dev libssl-dev libxml2-dev libxslt1-dev libbz2-dev libjpeg62-turbo-dev libtiff5-dev libopenjp2-7-dev zlib1g-dev" \
+RUN buildDeps="build-essential wget gcc libc6-dev libpcre3-dev libssl-dev libxml2-dev libxslt1-dev libbz2-dev libjpeg62-turbo-dev libtiff5-dev libopenjp2-7-dev zlib1g-dev" \
  && runDeps="gosu poppler-utils wv rsync lynx netcat libxml2 libxslt1.1 libjpeg62 libtiff5 libopenjp2-7" \
  && apt-get update \
  && apt-get install -y --no-install-recommends $buildDeps \


### PR DESCRIPTION
 - Arm64 support has been added for 5.1/5.1.1/debian.
 - Add build-essential to resolve Zlib dependency occuring during Pillow compilation.

Signed-off-by: Odidev <odidev@puresoftware.com>