### PR TITLE
 Replace "build-essential" with "dpkg-dev"

### DIFF
--- a/4.3/4.3.17/debian/Dockerfile
+++ b/4.3/4.3.17/debian/Dockerfile
@@ -19,8 +19,8 @@ RUN useradd --system -m -d /plone -U -u 500 plone \
 
 COPY buildout.cfg /plone/instance/
 
-RUN buildDeps="dpkg-dev wget gcc libc6-dev libpcre3-dev libssl-dev libxml2-dev libxslt1-dev libbz2-dev libjpeg62-turbo-dev libtiff5-dev libopenjp2-7-dev zlib1g-dev" \
- && runDeps="gosu poppler-utils wv rsync lynx netcat libxml2 libxslt1.1 libjpeg62 libtiff5 libopenjp2-7" \
+RUN buildDeps="dpkg-dev gcc libbz2-dev libc6-dev libjpeg62-turbo-dev libopenjp2-7-dev libpcre3-dev libssl-dev libtiff5-dev libxml2-dev libxslt1-dev wget zlib1g-dev" \
+ && runDeps="gosu libjpeg62 libopenjp2-7 libtiff5 libxml2 libxslt1.1 lynx netcat poppler-utils rsync wv" \
  && apt-get update \
  && apt-get install -y --no-install-recommends $buildDeps \
  && wget -O Plone.tgz https://launchpad.net/plone/$PLONE_MAJOR/$PLONE_VERSION/+download/Plone-$PLONE_VERSION-UnifiedInstaller.tgz \

--- a/4.3/4.3.17/debian/Dockerfile
+++ b/4.3/4.3.17/debian/Dockerfile
@@ -19,7 +19,7 @@ RUN useradd --system -m -d /plone -U -u 500 plone \
 
 COPY buildout.cfg /plone/instance/
 
-RUN buildDeps="build-essential wget gcc libc6-dev libpcre3-dev libssl-dev libxml2-dev libxslt1-dev libbz2-dev libjpeg62-turbo-dev libtiff5-dev libopenjp2-7-dev zlib1g-dev" \
+RUN buildDeps="dpkg-dev wget gcc libc6-dev libpcre3-dev libssl-dev libxml2-dev libxslt1-dev libbz2-dev libjpeg62-turbo-dev libtiff5-dev libopenjp2-7-dev zlib1g-dev" \
  && runDeps="gosu poppler-utils wv rsync lynx netcat libxml2 libxslt1.1 libjpeg62 libtiff5 libopenjp2-7" \
  && apt-get update \
  && apt-get install -y --no-install-recommends $buildDeps \

--- a/5.1/5.1.2/debian/Dockerfile
+++ b/5.1/5.1.2/debian/Dockerfile
@@ -19,8 +19,8 @@ RUN useradd --system -m -d /plone -U -u 500 plone \
 
 COPY buildout.cfg /plone/instance/
 
-RUN buildDeps="dpkg-dev wget gcc libc6-dev libpcre3-dev libssl-dev libxml2-dev libxslt1-dev libbz2-dev libjpeg62-turbo-dev libtiff5-dev libopenjp2-7-dev zlib1g-dev" \
- && runDeps="gosu poppler-utils wv rsync lynx netcat libxml2 libxslt1.1 libjpeg62 libtiff5 libopenjp2-7" \
+RUN buildDeps="dpkg-dev gcc libbz2-dev libc6-dev libjpeg62-turbo-dev libopenjp2-7-dev libpcre3-dev libssl-dev libtiff5-dev libxml2-dev libxslt1-dev wget zlib1g-dev" \
+ && runDeps="gosu libjpeg62 libopenjp2-7 libtiff5 libxml2 libxslt1.1 lynx netcat poppler-utils rsync wv" \
  && apt-get update \
  && apt-get install -y --no-install-recommends $buildDeps \
  && wget -O Plone.tgz https://launchpad.net/plone/$PLONE_MAJOR/$PLONE_VERSION/+download/Plone-$PLONE_VERSION-UnifiedInstaller.tgz \

--- a/5.1/5.1.2/debian/Dockerfile
+++ b/5.1/5.1.2/debian/Dockerfile
@@ -19,7 +19,7 @@ RUN useradd --system -m -d /plone -U -u 500 plone \
 
 COPY buildout.cfg /plone/instance/
 
-RUN buildDeps="build-essential wget gcc libc6-dev libpcre3-dev libssl-dev libxml2-dev libxslt1-dev libbz2-dev libjpeg62-turbo-dev libtiff5-dev libopenjp2-7-dev zlib1g-dev" \
+RUN buildDeps="dpkg-dev wget gcc libc6-dev libpcre3-dev libssl-dev libxml2-dev libxslt1-dev libbz2-dev libjpeg62-turbo-dev libtiff5-dev libopenjp2-7-dev zlib1g-dev" \
  && runDeps="gosu poppler-utils wv rsync lynx netcat libxml2 libxslt1.1 libjpeg62 libtiff5 libopenjp2-7" \
  && apt-get update \
  && apt-get install -y --no-install-recommends $buildDeps \


### PR DESCRIPTION
As discussed in https://github.com/plone/plone.docker/pull/102/files#r211417424.

This also sorts the dependency lists so that they can be more easily scanned visually to look for dups, etc. :+1: