### PR TITLE
Enable use in addons

### DIFF
--- a/5.2/5.2.1/debian/Dockerfile
+++ b/5.2/5.2.1/debian/Dockerfile
@@ -22,7 +22,7 @@ RUN useradd --system -m -d /plone -U -u 500 plone \
 COPY buildout.cfg /plone/instance/
 
 RUN buildDeps="dpkg-dev gcc libbz2-dev libc6-dev libffi-dev libjpeg62-turbo-dev libopenjp2-7-dev libpcre3-dev libssl-dev libtiff5-dev libxml2-dev libxslt1-dev wget zlib1g-dev" \
- && runDeps="gosu libjpeg62 libopenjp2-7 libtiff5 libxml2 libxslt1.1 lynx netcat poppler-utils rsync wv" \
+ && runDeps="gosu libjpeg62 libopenjp2-7 libtiff5 libxml2 libxslt1.1 lynx make netcat poppler-utils rsync wv" \
  && apt-get update \
  && apt-get install -y --no-install-recommends $buildDeps \
  && wget -O Plone.tgz https://launchpad.net/plone/$PLONE_MAJOR/$PLONE_VERSION/+download/$PLONE_VERSION_RELEASE.tgz \
@@ -33,6 +33,10 @@ RUN buildDeps="dpkg-dev gcc libbz2-dev libc6-dev libffi-dev libjpeg62-turbo-dev 
  && pip install pip==$PIP setuptools==$SETUPTOOLS zc.buildout==$ZC_BUILDOUT wheel==$WHEEL \
  && cd /plone/instance \
  && buildout \
+ && mkdir /plone/.buildout \
+ && echo "[buildout]" > /plone/.buildout/default.cfg \
+ && echo "download-cache = /plone/buildout-cache/downloads" >> /plone/.buildout/default.cfg \
+ && echo "eggs-directory = /plone/buildout-cache/eggs" >> /plone/.buildout/default.cfg \
  && ln -s /data/filestorage/ /plone/instance/var/filestorage \
  && ln -s /data/blobstorage /plone/instance/var/blobstorage \
  && find /data  -not -user plone -exec chown plone:plone {} \+ \


### PR DESCRIPTION
The idea is to have a `docker-compose.yml` file in one addon like this:

```yml
version: '2'
services:
  plone:
    container_name: plone
    image: plone:5.2.1
    volumes:
      - .:/app
```

And run `buildout` and `instance fg` from this image using the already present cache