### PR TITLE
Add find-links and sources parts to custom buildout

### DIFF
--- a/4.3/4.3.19/alpine/Dockerfile
+++ b/4.3/4.3.19/alpine/Dockerfile
@@ -48,6 +48,7 @@ RUN apk add --no-cache --virtual .build-deps \
  && apk add --no-cache --virtual .run-deps \
     su-exec \
     bash \
+    git \
     rsync \
     libxml2 \
     libxslt \

--- a/4.3/4.3.19/alpine/docker-initialize.py
+++ b/4.3/4.3.19/alpine/docker-initialize.py
@@ -126,6 +126,8 @@ class Environment(object):
         if os.path.exists(self.custom_conf):
             return
 
+        findlinks = self.env.get("FIND_LINKS", "").strip().split()
+
         eggs = self.env.get("PLONE_ADDONS",
                self.env.get("ADDONS", "")).strip().split()
 
@@ -144,6 +146,8 @@ class Environment(object):
         versions = self.env.get("PLONE_VERSIONS",
                    self.env.get("VERSIONS", "")).strip().split()
 
+        sources = self.env.get("SOURCES", "").strip().split(",")
+
         # If profiles not provided. Install ADDONS :default profiles
         if not profiles:
             for egg in eggs:
@@ -155,11 +159,13 @@ class Environment(object):
             return
 
         buildout = BUILDOUT_TEMPLATE.format(
+            findlinks="\n\t".join(findlinks),
             eggs="\n\t".join(eggs),
             zcml="\n\t".join(zcml),
             develop="\n\t".join(develop),
             profiles="\n\t".join(profiles),
             versions="\n".join(versions),
+            sources="\n".join(sources),
             site=site or "Plone",
             enabled=enabled,
         )
@@ -218,6 +224,7 @@ CORS_TEMPLACE = """<configure
 BUILDOUT_TEMPLATE = """
 [buildout]
 extends = develop.cfg
+find-links += {findlinks}
 develop += {develop}
 eggs += {eggs}
 zcml += {zcml}
@@ -229,6 +236,9 @@ profiles += {profiles}
 
 [versions]
 {versions}
+
+[sources]
+{sources}
 """
 
 ZEO_INSTANCE_TEMPLATE = """

--- a/4.3/4.3.19/debian/Dockerfile
+++ b/4.3/4.3.19/debian/Dockerfile
@@ -21,7 +21,7 @@ RUN useradd --system -m -d /plone -U -u 500 plone \
 COPY buildout.cfg /plone/instance/
 
 RUN buildDeps="dpkg-dev gcc libbz2-dev libc6-dev libjpeg62-turbo-dev libopenjp2-7-dev libpcre3-dev libssl-dev libtiff5-dev libxml2-dev libxslt1-dev wget zlib1g-dev" \
- && runDeps="gosu libjpeg62 libopenjp2-7 libtiff5 libxml2 libxslt1.1 lynx netcat poppler-utils rsync wv" \
+ && runDeps="git gosu libjpeg62 libopenjp2-7 libtiff5 libxml2 libxslt1.1 lynx netcat poppler-utils rsync wv" \
  && apt-get update \
  && apt-get install -y --no-install-recommends $buildDeps \
  && wget -O Plone.tgz https://launchpad.net/plone/$PLONE_MAJOR/$PLONE_VERSION/+download/Plone-$PLONE_VERSION-UnifiedInstaller.tgz \

--- a/4.3/4.3.19/debian/docker-initialize.py
+++ b/4.3/4.3.19/debian/docker-initialize.py
@@ -126,6 +126,8 @@ class Environment(object):
         if os.path.exists(self.custom_conf):
             return
 
+        findlinks = self.env.get("FIND_LINKS", "").strip().split()
+
         eggs = self.env.get("PLONE_ADDONS",
                self.env.get("ADDONS", "")).strip().split()
 
@@ -144,6 +146,8 @@ class Environment(object):
         versions = self.env.get("PLONE_VERSIONS",
                    self.env.get("VERSIONS", "")).strip().split()
 
+        sources = self.env.get("SOURCES", "").strip().split(",")
+
         # If profiles not provided. Install ADDONS :default profiles
         if not profiles:
             for egg in eggs:
@@ -155,11 +159,13 @@ class Environment(object):
             return
 
         buildout = BUILDOUT_TEMPLATE.format(
+            findlinks="\n\t".join(findlinks),
             eggs="\n\t".join(eggs),
             zcml="\n\t".join(zcml),
             develop="\n\t".join(develop),
             profiles="\n\t".join(profiles),
             versions="\n".join(versions),
+            sources="\n".join(sources),
             site=site or "Plone",
             enabled=enabled,
         )
@@ -218,6 +224,7 @@ CORS_TEMPLACE = """<configure
 BUILDOUT_TEMPLATE = """
 [buildout]
 extends = develop.cfg
+find-links += {findlinks}
 develop += {develop}
 eggs += {eggs}
 zcml += {zcml}
@@ -229,6 +236,9 @@ profiles += {profiles}
 
 [versions]
 {versions}
+
+[sources]
+{sources}
 """
 
 ZEO_INSTANCE_TEMPLATE = """

--- a/5.1/5.1.6/alpine/Dockerfile
+++ b/5.1/5.1.6/alpine/Dockerfile
@@ -48,6 +48,7 @@ RUN apk add --no-cache --virtual .build-deps \
 && apk add --no-cache --virtual .run-deps \
     su-exec \
     bash \
+    git \
     rsync \
     libxml2 \
     libxslt \

--- a/5.1/5.1.6/alpine/docker-initialize.py
+++ b/5.1/5.1.6/alpine/docker-initialize.py
@@ -126,6 +126,8 @@ class Environment(object):
         if os.path.exists(self.custom_conf):
             return
 
+        findlinks = self.env.get("FIND_LINKS", "").strip().split()
+
         eggs = self.env.get("PLONE_ADDONS",
                self.env.get("ADDONS", "")).strip().split()
 
@@ -144,6 +146,8 @@ class Environment(object):
         versions = self.env.get("PLONE_VERSIONS",
                    self.env.get("VERSIONS", "")).strip().split()
 
+        sources = self.env.get("SOURCES", "").strip().split(",")
+
         # If profiles not provided. Install ADDONS :default profiles
         if not profiles:
             for egg in eggs:
@@ -155,11 +159,13 @@ class Environment(object):
             return
 
         buildout = BUILDOUT_TEMPLATE.format(
+            findlinks="\n\t".join(findlinks),
             eggs="\n\t".join(eggs),
             zcml="\n\t".join(zcml),
             develop="\n\t".join(develop),
             profiles="\n\t".join(profiles),
             versions="\n".join(versions),
+            sources="\n".join(sources),
             site=site or "Plone",
             enabled=enabled,
         )
@@ -218,6 +224,7 @@ CORS_TEMPLACE = """<configure
 BUILDOUT_TEMPLATE = """
 [buildout]
 extends = develop.cfg
+find-links += {findlinks}
 develop += {develop}
 eggs += {eggs}
 zcml += {zcml}
@@ -229,6 +236,9 @@ profiles += {profiles}
 
 [versions]
 {versions}
+
+[sources]
+{sources}
 """
 
 ZEO_INSTANCE_TEMPLATE = """

--- a/5.1/5.1.6/debian/Dockerfile
+++ b/5.1/5.1.6/debian/Dockerfile
@@ -21,7 +21,7 @@ RUN useradd --system -m -d /plone -U -u 500 plone \
 COPY buildout.cfg /plone/instance/
 
 RUN buildDeps="dpkg-dev gcc libbz2-dev libc6-dev libjpeg62-turbo-dev libopenjp2-7-dev libpcre3-dev libssl-dev libtiff5-dev libxml2-dev libxslt1-dev wget zlib1g-dev" \
- && runDeps="gosu libjpeg62 libopenjp2-7 libtiff5 libxml2 libxslt1.1 lynx netcat poppler-utils rsync wv" \
+ && runDeps="git gosu libjpeg62 libopenjp2-7 libtiff5 libxml2 libxslt1.1 lynx netcat poppler-utils rsync wv" \
  && apt-get update \
  && apt-get install -y --no-install-recommends $buildDeps \
  && wget -O Plone.tgz https://launchpad.net/plone/$PLONE_MAJOR/$PLONE_VERSION/+download/Plone-$PLONE_VERSION-UnifiedInstaller.tgz \

--- a/5.1/5.1.6/debian/docker-initialize.py
+++ b/5.1/5.1.6/debian/docker-initialize.py
@@ -126,6 +126,8 @@ class Environment(object):
         if os.path.exists(self.custom_conf):
             return
 
+        findlinks = self.env.get("FIND_LINKS", "").strip().split()
+
         eggs = self.env.get("PLONE_ADDONS",
                self.env.get("ADDONS", "")).strip().split()
 
@@ -144,6 +146,8 @@ class Environment(object):
         versions = self.env.get("PLONE_VERSIONS",
                    self.env.get("VERSIONS", "")).strip().split()
 
+        sources = self.env.get("SOURCES", "").strip().split(",")
+
         # If profiles not provided. Install ADDONS :default profiles
         if not profiles:
             for egg in eggs:
@@ -155,11 +159,13 @@ class Environment(object):
             return
 
         buildout = BUILDOUT_TEMPLATE.format(
+            findlinks="\n\t".join(findlinks),
             eggs="\n\t".join(eggs),
             zcml="\n\t".join(zcml),
             develop="\n\t".join(develop),
             profiles="\n\t".join(profiles),
             versions="\n".join(versions),
+            sources="\n".join(sources),
             site=site or "Plone",
             enabled=enabled,
         )
@@ -218,6 +224,7 @@ CORS_TEMPLACE = """<configure
 BUILDOUT_TEMPLATE = """
 [buildout]
 extends = develop.cfg
+find-links += {findlinks}
 develop += {develop}
 eggs += {eggs}
 zcml += {zcml}
@@ -229,6 +236,9 @@ profiles += {profiles}
 
 [versions]
 {versions}
+
+[sources]
+{sources}
 """
 
 ZEO_INSTANCE_TEMPLATE = """

--- a/5.2/5.2.2/alpine/Dockerfile
+++ b/5.2/5.2.2/alpine/Dockerfile
@@ -49,6 +49,7 @@ RUN apk add --no-cache --virtual .build-deps \
 && apk add --no-cache --virtual .run-deps \
     su-exec \
     bash \
+    git \
     rsync \
     libxml2 \
     libxslt \

--- a/5.2/5.2.2/alpine/docker-initialize.py
+++ b/5.2/5.2.2/alpine/docker-initialize.py
@@ -126,6 +126,8 @@ class Environment(object):
         if os.path.exists(self.custom_conf):
             return
 
+        findlinks = self.env.get("FIND_LINKS", "").strip().split()
+
         eggs = self.env.get("PLONE_ADDONS",
                self.env.get("ADDONS", "")).strip().split()
 
@@ -144,6 +146,8 @@ class Environment(object):
         versions = self.env.get("PLONE_VERSIONS",
                    self.env.get("VERSIONS", "")).strip().split()
 
+        sources = self.env.get("SOURCES", "").strip().split(",")
+
         # If profiles not provided. Install ADDONS :default profiles
         if not profiles:
             for egg in eggs:
@@ -155,11 +159,13 @@ class Environment(object):
             return
 
         buildout = BUILDOUT_TEMPLATE.format(
+            findlinks="\n\t".join(findlinks),
             eggs="\n\t".join(eggs),
             zcml="\n\t".join(zcml),
             develop="\n\t".join(develop),
             profiles="\n\t".join(profiles),
             versions="\n".join(versions),
+            sources="\n".join(sources),
             site=site or "Plone",
             enabled=enabled,
         )
@@ -218,6 +224,7 @@ CORS_TEMPLACE = """<configure
 BUILDOUT_TEMPLATE = """
 [buildout]
 extends = develop.cfg
+find-links += {findlinks}
 develop += {develop}
 eggs += {eggs}
 zcml += {zcml}
@@ -229,6 +236,9 @@ profiles += {profiles}
 
 [versions]
 {versions}
+
+[sources]
+{sources}
 """
 
 ZEO_INSTANCE_TEMPLATE = """

--- a/5.2/5.2.2/debian/Dockerfile
+++ b/5.2/5.2.2/debian/Dockerfile
@@ -22,7 +22,7 @@ RUN useradd --system -m -d /plone -U -u 500 plone \
 COPY buildout.cfg /plone/instance/
 
 RUN buildDeps="dpkg-dev gcc libbz2-dev libc6-dev libffi-dev libjpeg62-turbo-dev libopenjp2-7-dev libpcre3-dev libssl-dev libtiff5-dev libxml2-dev libxslt1-dev wget zlib1g-dev" \
- && runDeps="gosu libjpeg62 libopenjp2-7 libtiff5 libxml2 libxslt1.1 lynx netcat poppler-utils rsync wv" \
+ && runDeps="git gosu libjpeg62 libopenjp2-7 libtiff5 libxml2 libxslt1.1 lynx netcat poppler-utils rsync wv" \
  && apt-get update \
  && apt-get install -y --no-install-recommends $buildDeps \
  && wget -O Plone.tgz https://launchpad.net/plone/$PLONE_MAJOR/$PLONE_VERSION/+download/$PLONE_VERSION_RELEASE.tgz \

--- a/5.2/5.2.2/debian/docker-initialize.py
+++ b/5.2/5.2.2/debian/docker-initialize.py
@@ -126,6 +126,8 @@ class Environment(object):
         if os.path.exists(self.custom_conf):
             return
 
+        findlinks = self.env.get("FIND_LINKS", "").strip().split()
+
         eggs = self.env.get("PLONE_ADDONS",
                self.env.get("ADDONS", "")).strip().split()
 
@@ -155,6 +157,7 @@ class Environment(object):
             return
 
         buildout = BUILDOUT_TEMPLATE.format(
+            findlinks="\n\t".join(findlinks),
             eggs="\n\t".join(eggs),
             zcml="\n\t".join(zcml),
             develop="\n\t".join(develop),
@@ -218,6 +221,7 @@ CORS_TEMPLACE = """<configure
 BUILDOUT_TEMPLATE = """
 [buildout]
 extends = develop.cfg
+find-links += {findlinks}
 develop += {develop}
 eggs += {eggs}
 zcml += {zcml}

--- a/5.2/5.2.2/debian/docker-initialize.py
+++ b/5.2/5.2.2/debian/docker-initialize.py
@@ -146,6 +146,8 @@ class Environment(object):
         versions = self.env.get("PLONE_VERSIONS",
                    self.env.get("VERSIONS", "")).strip().split()
 
+        sources = self.env.get("SOURCES", "").strip().split(";")
+
         # If profiles not provided. Install ADDONS :default profiles
         if not profiles:
             for egg in eggs:
@@ -163,6 +165,7 @@ class Environment(object):
             develop="\n\t".join(develop),
             profiles="\n\t".join(profiles),
             versions="\n".join(versions),
+            sources="\n".join(sources),
             site=site or "Plone",
             enabled=enabled,
         )
@@ -233,6 +236,9 @@ profiles += {profiles}
 
 [versions]
 {versions}
+
+[sources]
+{sources}
 """
 
 ZEO_INSTANCE_TEMPLATE = """

--- a/5.2/5.2.2/debian/docker-initialize.py
+++ b/5.2/5.2.2/debian/docker-initialize.py
@@ -146,7 +146,7 @@ class Environment(object):
         versions = self.env.get("PLONE_VERSIONS",
                    self.env.get("VERSIONS", "")).strip().split()
 
-        sources = self.env.get("SOURCES", "").strip().split(";")
+        sources = self.env.get("SOURCES", "").strip().split(",")
 
         # If profiles not provided. Install ADDONS :default profiles
         if not profiles:

--- a/5.2/5.2.2/python2/Dockerfile
+++ b/5.2/5.2.2/python2/Dockerfile
@@ -22,7 +22,7 @@ RUN useradd --system -m -d /plone -U -u 500 plone \
 COPY buildout.cfg /plone/instance/
 
 RUN buildDeps="dpkg-dev gcc libbz2-dev libc6-dev libffi-dev libjpeg62-turbo-dev libopenjp2-7-dev libpcre3-dev libssl-dev libtiff5-dev libxml2-dev libxslt1-dev wget zlib1g-dev" \
- && runDeps="gosu libjpeg62 libopenjp2-7 libtiff5 libxml2 libxslt1.1 lynx netcat poppler-utils rsync wv" \
+ && runDeps="git gosu libjpeg62 libopenjp2-7 libtiff5 libxml2 libxslt1.1 lynx netcat poppler-utils rsync wv" \
  && apt-get update \
  && apt-get install -y --no-install-recommends $buildDeps \
  && wget -O Plone.tgz https://launchpad.net/plone/$PLONE_MAJOR/$PLONE_VERSION/+download/$PLONE_VERSION_RELEASE.tgz \

--- a/5.2/5.2.2/python2/docker-initialize.py
+++ b/5.2/5.2.2/python2/docker-initialize.py
@@ -126,6 +126,8 @@ class Environment(object):
         if os.path.exists(self.custom_conf):
             return
 
+        findlinks = self.env.get("FIND_LINKS", "").strip().split()
+
         eggs = self.env.get("PLONE_ADDONS",
                self.env.get("ADDONS", "")).strip().split()
 
@@ -144,6 +146,8 @@ class Environment(object):
         versions = self.env.get("PLONE_VERSIONS",
                    self.env.get("VERSIONS", "")).strip().split()
 
+        sources = self.env.get("SOURCES", "").strip().split(",")
+
         # If profiles not provided. Install ADDONS :default profiles
         if not profiles:
             for egg in eggs:
@@ -155,11 +159,13 @@ class Environment(object):
             return
 
         buildout = BUILDOUT_TEMPLATE.format(
+            findlinks="\n\t".join(findlinks),
             eggs="\n\t".join(eggs),
             zcml="\n\t".join(zcml),
             develop="\n\t".join(develop),
             profiles="\n\t".join(profiles),
             versions="\n".join(versions),
+            sources="\n".join(sources),
             site=site or "Plone",
             enabled=enabled,
         )
@@ -218,6 +224,7 @@ CORS_TEMPLACE = """<configure
 BUILDOUT_TEMPLATE = """
 [buildout]
 extends = develop.cfg
+find-links += {findlinks}
 develop += {develop}
 eggs += {eggs}
 zcml += {zcml}
@@ -229,6 +236,9 @@ profiles += {profiles}
 
 [versions]
 {versions}
+
+[sources]
+{sources}
 """
 
 ZEO_INSTANCE_TEMPLATE = """

--- a/5.2/5.2.2/python36/Dockerfile
+++ b/5.2/5.2.2/python36/Dockerfile
@@ -22,7 +22,7 @@ RUN useradd --system -m -d /plone -U -u 500 plone \
 COPY buildout.cfg /plone/instance/
 
 RUN buildDeps="dpkg-dev gcc libbz2-dev libc6-dev libffi-dev libjpeg62-turbo-dev libopenjp2-7-dev libpcre3-dev libssl-dev libtiff5-dev libxml2-dev libxslt1-dev wget zlib1g-dev" \
- && runDeps="gosu libjpeg62 libopenjp2-7 libtiff5 libxml2 libxslt1.1 lynx netcat poppler-utils rsync wv" \
+ && runDeps="git gosu libjpeg62 libopenjp2-7 libtiff5 libxml2 libxslt1.1 lynx netcat poppler-utils rsync wv" \
  && apt-get update \
  && apt-get install -y --no-install-recommends $buildDeps \
  && wget -O Plone.tgz https://launchpad.net/plone/$PLONE_MAJOR/$PLONE_VERSION/+download/$PLONE_VERSION_RELEASE.tgz \

--- a/5.2/5.2.2/python36/docker-initialize.py
+++ b/5.2/5.2.2/python36/docker-initialize.py
@@ -126,6 +126,8 @@ class Environment(object):
         if os.path.exists(self.custom_conf):
             return
 
+        findlinks = self.env.get("FIND_LINKS", "").strip().split()
+
         eggs = self.env.get("PLONE_ADDONS",
                self.env.get("ADDONS", "")).strip().split()
 
@@ -144,6 +146,8 @@ class Environment(object):
         versions = self.env.get("PLONE_VERSIONS",
                    self.env.get("VERSIONS", "")).strip().split()
 
+        sources = self.env.get("SOURCES", "").strip().split(",")
+
         # If profiles not provided. Install ADDONS :default profiles
         if not profiles:
             for egg in eggs:
@@ -155,11 +159,13 @@ class Environment(object):
             return
 
         buildout = BUILDOUT_TEMPLATE.format(
+            findlinks="\n\t".join(findlinks),
             eggs="\n\t".join(eggs),
             zcml="\n\t".join(zcml),
             develop="\n\t".join(develop),
             profiles="\n\t".join(profiles),
             versions="\n".join(versions),
+            sources="\n".join(sources),
             site=site or "Plone",
             enabled=enabled,
         )
@@ -218,6 +224,7 @@ CORS_TEMPLACE = """<configure
 BUILDOUT_TEMPLATE = """
 [buildout]
 extends = develop.cfg
+find-links += {findlinks}
 develop += {develop}
 eggs += {eggs}
 zcml += {zcml}
@@ -229,6 +236,9 @@ profiles += {profiles}
 
 [versions]
 {versions}
+
+[sources]
+{sources}
 """
 
 ZEO_INSTANCE_TEMPLATE = """

--- a/5.2/5.2.2/python37/Dockerfile
+++ b/5.2/5.2.2/python37/Dockerfile
@@ -22,7 +22,7 @@ RUN useradd --system -m -d /plone -U -u 500 plone \
 COPY buildout.cfg /plone/instance/
 
 RUN buildDeps="dpkg-dev gcc libbz2-dev libc6-dev libffi-dev libjpeg62-turbo-dev libopenjp2-7-dev libpcre3-dev libssl-dev libtiff5-dev libxml2-dev libxslt1-dev wget zlib1g-dev" \
- && runDeps="gosu libjpeg62 libopenjp2-7 libtiff5 libxml2 libxslt1.1 lynx netcat poppler-utils rsync wv" \
+ && runDeps="git gosu libjpeg62 libopenjp2-7 libtiff5 libxml2 libxslt1.1 lynx netcat poppler-utils rsync wv" \
  && apt-get update \
  && apt-get install -y --no-install-recommends $buildDeps \
  && wget -O Plone.tgz https://launchpad.net/plone/$PLONE_MAJOR/$PLONE_VERSION/+download/$PLONE_VERSION_RELEASE.tgz \

--- a/5.2/5.2.2/python37/docker-initialize.py
+++ b/5.2/5.2.2/python37/docker-initialize.py
@@ -126,6 +126,8 @@ class Environment(object):
         if os.path.exists(self.custom_conf):
             return
 
+        findlinks = self.env.get("FIND_LINKS", "").strip().split()
+
         eggs = self.env.get("PLONE_ADDONS",
                self.env.get("ADDONS", "")).strip().split()
 
@@ -144,6 +146,8 @@ class Environment(object):
         versions = self.env.get("PLONE_VERSIONS",
                    self.env.get("VERSIONS", "")).strip().split()
 
+        sources = self.env.get("SOURCES", "").strip().split(",")
+
         # If profiles not provided. Install ADDONS :default profiles
         if not profiles:
             for egg in eggs:
@@ -155,11 +159,13 @@ class Environment(object):
             return
 
         buildout = BUILDOUT_TEMPLATE.format(
+            findlinks="\n\t".join(findlinks),
             eggs="\n\t".join(eggs),
             zcml="\n\t".join(zcml),
             develop="\n\t".join(develop),
             profiles="\n\t".join(profiles),
             versions="\n".join(versions),
+            sources="\n".join(sources),
             site=site or "Plone",
             enabled=enabled,
         )
@@ -218,6 +224,7 @@ CORS_TEMPLACE = """<configure
 BUILDOUT_TEMPLATE = """
 [buildout]
 extends = develop.cfg
+find-links += {findlinks}
 develop += {develop}
 eggs += {eggs}
 zcml += {zcml}
@@ -229,6 +236,9 @@ profiles += {profiles}
 
 [versions]
 {versions}
+
+[sources]
+{sources}
 """
 
 ZEO_INSTANCE_TEMPLATE = """

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Add find-links and sources part to custom buildout
+  [pnicolli]
 - Fixed interaction between SITE env var and a zeo setup. Fixes issue #135
   [pnicolli]
 - Update docs

--- a/README.md
+++ b/README.md
@@ -108,7 +108,7 @@ $ docker run -p 8080:8080 -e SITE="mysite" -e ADDONS="eea.facetednavigation coll
 
 To use specific add-ons versions:
 
-```console
+```bash
  -e ADDONS="eea.facetednavigation collective.easyform" -e VERSIONS="eea.facetednavigation=13.3 collective.easyform=2.1.0"
 ```
 
@@ -130,6 +130,16 @@ $ curl -H 'Accept: application/json' http://localhost:8080/plone
 * `PLONE_PROFILES, PROFILES` - GenericSetup profiles to include when `SITE` environment provided.
 * `PLONE_ZCML`, `ZCML` - Include custom Plone add-ons ZCML files
 * `PLONE_DEVELOP`, `DEVELOP` - Develop new or existing Plone add-ons
+* `FIND_LINKS` - Add custom `find-links` to the buildout configuration
+* `SOURCES` - Add custom `sources` to the buildout configuration
+
+In order to add custom sources, the `SOURCES` env var needs to be a string containing a *comma*-separated list of sources. This is different from the other environment variables described above, which are *space*-separated.
+
+For example:
+
+```bash
+ -e SOURCES="plone.restapi = git https://github.com/plone/plone.restapi,plone.staticresources = git https://github.com/plone/plone.staticresources"
+```
 
 **ZEO:**
 


### PR DESCRIPTION
Adding find-links to buildout allows us to use custom eggs repositories. We currently use this to deploy eggs that we publish to a private pypi registry.

Regarding sources, we use this to deploy the same eggs from source in a staging environment on k8s.
I'm not sure about using a different separator for the sources env var though. Is there a better way to do this?

If these changes are ok, I can take care of replicating these to the latest 5.1, 5.0 and 4.x, if you think it's useful.

You can try the public docker image `pnicolli/plone` if you want to test these features.