### PR TITLE
Only extend develop.cfg when needed

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+CHANGES.md merge=union

--- a/5.2/5.2.2/alpine/docker-initialize.py
+++ b/5.2/5.2.2/alpine/docker-initialize.py
@@ -224,9 +224,13 @@ class Environment(object):
         versions = self.env.get("PLONE_VERSIONS",
                    self.env.get("VERSIONS", "")).strip().split()
 
-        sources = self.env.get("SOURCES", "").strip().split(",")
+        sources = self.env.get("SOURCES", "").strip()
+        sources = sources and [x.strip() for x in sources.split(",")]
 
         relstorage = self.relstorage_conf()
+
+        buildout_extends = ((develop or sources)
+                            and "develop.cfg" or "buildout.cfg")
 
         # If profiles not provided. Install ADDONS :default profiles
         if not profiles:
@@ -239,6 +243,7 @@ class Environment(object):
             return
 
         buildout = BUILDOUT_TEMPLATE.format(
+            buildout_extends=buildout_extends,
             findlinks="\n\t".join(findlinks),
             eggs="\n\t".join(eggs),
             zcml="\n\t".join(zcml),
@@ -304,7 +309,7 @@ CORS_TEMPLATE = """<configure
 
 BUILDOUT_TEMPLATE = """
 [buildout]
-extends = develop.cfg
+extends = {buildout_extends}
 find-links += {findlinks}
 develop += {develop}
 eggs += {eggs}

--- a/5.2/5.2.2/debian/docker-initialize.py
+++ b/5.2/5.2.2/debian/docker-initialize.py
@@ -224,9 +224,13 @@ class Environment(object):
         versions = self.env.get("PLONE_VERSIONS",
                    self.env.get("VERSIONS", "")).strip().split()
 
-        sources = self.env.get("SOURCES", "").strip().split(",")
+        sources = self.env.get("SOURCES", "").strip()
+        sources = sources and [x.strip() for x in sources.split(",")]
 
         relstorage = self.relstorage_conf()
+
+        buildout_extends = ((develop or sources)
+                            and "develop.cfg" or "buildout.cfg")
 
         # If profiles not provided. Install ADDONS :default profiles
         if not profiles:
@@ -239,6 +243,7 @@ class Environment(object):
             return
 
         buildout = BUILDOUT_TEMPLATE.format(
+            buildout_extends=buildout_extends,
             findlinks="\n\t".join(findlinks),
             eggs="\n\t".join(eggs),
             zcml="\n\t".join(zcml),
@@ -304,7 +309,7 @@ CORS_TEMPLATE = """<configure
 
 BUILDOUT_TEMPLATE = """
 [buildout]
-extends = develop.cfg
+extends = {buildout_extends}
 find-links += {findlinks}
 develop += {develop}
 eggs += {eggs}

--- a/5.2/5.2.2/python2/docker-initialize.py
+++ b/5.2/5.2.2/python2/docker-initialize.py
@@ -224,9 +224,13 @@ class Environment(object):
         versions = self.env.get("PLONE_VERSIONS",
                    self.env.get("VERSIONS", "")).strip().split()
 
-        sources = self.env.get("SOURCES", "").strip().split(",")
+        sources = self.env.get("SOURCES", "").strip()
+        sources = sources and [x.strip() for x in sources.split(",")]
 
         relstorage = self.relstorage_conf()
+
+        buildout_extends = ((develop or sources)
+                            and "develop.cfg" or "buildout.cfg")
 
         # If profiles not provided. Install ADDONS :default profiles
         if not profiles:
@@ -239,6 +243,7 @@ class Environment(object):
             return
 
         buildout = BUILDOUT_TEMPLATE.format(
+            buildout_extends=buildout_extends,
             findlinks="\n\t".join(findlinks),
             eggs="\n\t".join(eggs),
             zcml="\n\t".join(zcml),
@@ -304,7 +309,7 @@ CORS_TEMPLATE = """<configure
 
 BUILDOUT_TEMPLATE = """
 [buildout]
-extends = develop.cfg
+extends = {buildout_extends}
 find-links += {findlinks}
 develop += {develop}
 eggs += {eggs}

--- a/5.2/5.2.2/python36/docker-initialize.py
+++ b/5.2/5.2.2/python36/docker-initialize.py
@@ -224,9 +224,13 @@ class Environment(object):
         versions = self.env.get("PLONE_VERSIONS",
                    self.env.get("VERSIONS", "")).strip().split()
 
-        sources = self.env.get("SOURCES", "").strip().split(",")
+        sources = self.env.get("SOURCES", "").strip()
+        sources = sources and [x.strip() for x in sources.split(",")]
 
         relstorage = self.relstorage_conf()
+
+        buildout_extends = ((develop or sources)
+                            and "develop.cfg" or "buildout.cfg")
 
         # If profiles not provided. Install ADDONS :default profiles
         if not profiles:
@@ -239,6 +243,7 @@ class Environment(object):
             return
 
         buildout = BUILDOUT_TEMPLATE.format(
+            buildout_extends=buildout_extends,
             findlinks="\n\t".join(findlinks),
             eggs="\n\t".join(eggs),
             zcml="\n\t".join(zcml),
@@ -304,7 +309,7 @@ CORS_TEMPLATE = """<configure
 
 BUILDOUT_TEMPLATE = """
 [buildout]
-extends = develop.cfg
+extends = {buildout_extends}
 find-links += {findlinks}
 develop += {develop}
 eggs += {eggs}

--- a/5.2/5.2.2/python37/docker-initialize.py
+++ b/5.2/5.2.2/python37/docker-initialize.py
@@ -224,9 +224,13 @@ class Environment(object):
         versions = self.env.get("PLONE_VERSIONS",
                    self.env.get("VERSIONS", "")).strip().split()
 
-        sources = self.env.get("SOURCES", "").strip().split(",")
+        sources = self.env.get("SOURCES", "").strip()
+        sources = sources and [x.strip() for x in sources.split(",")]
 
         relstorage = self.relstorage_conf()
+
+        buildout_extends = ((develop or sources)
+                            and "develop.cfg" or "buildout.cfg")
 
         # If profiles not provided. Install ADDONS :default profiles
         if not profiles:
@@ -239,6 +243,7 @@ class Environment(object):
             return
 
         buildout = BUILDOUT_TEMPLATE.format(
+            buildout_extends=buildout_extends,
             findlinks="\n\t".join(findlinks),
             eggs="\n\t".join(eggs),
             zcml="\n\t".join(zcml),
@@ -304,7 +309,7 @@ CORS_TEMPLATE = """<configure
 
 BUILDOUT_TEMPLATE = """
 [buildout]
-extends = develop.cfg
+extends = {buildout_extends}
 find-links += {findlinks}
 develop += {develop}
 eggs += {eggs}

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Only extend develop.cfg when needed
+  [@pnicolli]
 - Add RelStorage support
   [@pnicolli]
 - Typo fix: CORS_TEMPLACE


### PR DESCRIPTION
I feel like we don't really need to extend ``develop.cfg`` every time we use the set some environment variables here.
For example, it's extended when the ``ADDONS`` variable is set, even if we don't really need all the development parts that are in that buildout.

With this change, ``develop.cfg`` is extended only if ``DEVELOP`` or ``SOURCES`` are set.

On a side note, this also opens up the possibility to implement an environment variable that allows to define additional custom files to extend (for example a versions file from a remote url). This is another feature I would love to add soon :)