### PR TITLE
Extend latest additions to older versions and fix official tests

### DIFF
--- a/5.1/5.1.6/alpine/Dockerfile
+++ b/5.1/5.1.6/alpine/Dockerfile
@@ -22,13 +22,14 @@ RUN addgroup -g 500 plone \
 COPY buildout.cfg /plone/instance/
 
 RUN apk add --no-cache --virtual .build-deps \
-    gcc \
+    build-base \
     libc-dev \
     zlib-dev \
     libjpeg-turbo-dev \
     libpng-dev \
     libxml2-dev \
     libxslt-dev \
+    openldap-dev \
     pcre-dev \
     libffi-dev \
 && wget -O Plone.tgz https://launchpad.net/plone/$PLONE_MAJOR/$PLONE_VERSION/+download/Plone-$PLONE_VERSION-UnifiedInstaller.tgz \

--- a/5.1/5.1.6/alpine/buildout.cfg
+++ b/5.1/5.1.6/alpine/buildout.cfg
@@ -14,6 +14,7 @@ parts +=
   plonesite
 
 eggs +=
+  pas.plugins.ldap
   plone.restapi
 
 [client1]

--- a/5.1/5.1.6/debian/Dockerfile
+++ b/5.1/5.1.6/debian/Dockerfile
@@ -20,7 +20,7 @@ RUN useradd --system -m -d /plone -U -u 500 plone \
 
 COPY buildout.cfg /plone/instance/
 
-RUN buildDeps="dpkg-dev gcc libbz2-dev libc6-dev libjpeg62-turbo-dev libopenjp2-7-dev libpcre3-dev libssl-dev libtiff5-dev libxml2-dev libxslt1-dev wget zlib1g-dev" \
+RUN buildDeps="dpkg-dev gcc libbz2-dev libc6-dev libjpeg62-turbo-dev libldap2-dev libopenjp2-7-dev libpcre3-dev libsasl2-dev libssl-dev libtiff5-dev libxml2-dev libxslt1-dev wget zlib1g-dev" \
  && runDeps="git gosu libjpeg62 libopenjp2-7 libtiff5 libxml2 libxslt1.1 lynx netcat poppler-utils rsync wv" \
  && apt-get update \
  && apt-get install -y --no-install-recommends $buildDeps \

--- a/5.1/5.1.6/debian/buildout.cfg
+++ b/5.1/5.1.6/debian/buildout.cfg
@@ -14,6 +14,7 @@ parts +=
   plonesite
 
 eggs +=
+  pas.plugins.ldap
   plone.restapi
 
 [client1]

--- a/5.2/5.2.2/alpine/docker-initialize.py
+++ b/5.2/5.2.2/alpine/docker-initialize.py
@@ -247,7 +247,6 @@ class Environment(object):
             findlinks="\n\t".join(findlinks),
             eggs="\n\t".join(eggs),
             zcml="\n\t".join(zcml),
-            relstorage=relstorage,
             develop="\n\t".join(develop),
             profiles="\n\t".join(profiles),
             versions="\n".join(versions),
@@ -320,10 +319,6 @@ develop += {develop}
 eggs += {eggs}
 zcml += {zcml}
 
-[instance]
-rel-storage =
-  {relstorage}
-
 [plonesite]
 enabled = {enabled}
 site-id = {site}
@@ -331,9 +326,6 @@ profiles += {profiles}
 
 [versions]
 {versions}
-
-[sources]
-{sources}
 """
 
 ZEO_INSTANCE_TEMPLATE = """

--- a/5.2/5.2.2/alpine/docker-initialize.py
+++ b/5.2/5.2.2/alpine/docker-initialize.py
@@ -251,7 +251,6 @@ class Environment(object):
             develop="\n\t".join(develop),
             profiles="\n\t".join(profiles),
             versions="\n".join(versions),
-            sources="\n".join(sources),
             site=site or "Plone",
             enabled=enabled,
         )

--- a/5.2/5.2.2/alpine/docker-initialize.py
+++ b/5.2/5.2.2/alpine/docker-initialize.py
@@ -260,9 +260,15 @@ class Environment(object):
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
         if server:
-            buildout += ZEO_INSTANCE_TEMPLATE.format(
-                zeoaddress=server,
-            )
+            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server)
+
+        # Add RelStorage configuration if needed
+        if relstorage:
+            buildout += RELSTORAGE_TEMPLATE.format(relstorage=relstorage)
+
+        # Add sources configuration if needed
+        if sources:
+            buildout += SOURCES_TEMPLATE.format(sources="\n".join(sources))
 
         with open(self.custom_conf, 'w') as cfile:
             cfile.write(buildout)
@@ -339,6 +345,20 @@ zeo-address = {zeoaddress}
 shared-blob = off
 http-fast-listen = off
 """
+
+RELSTORAGE_TEMPLATE = """
+
+[instance]
+rel-storage =
+  {relstorage}
+"""
+
+SOURCES_TEMPLATE = """
+
+[sources]
+{sources}
+"""
+
 
 def initialize():
     """ Configure Plone instance as ZEO Client

--- a/5.2/5.2.2/debian/docker-initialize.py
+++ b/5.2/5.2.2/debian/docker-initialize.py
@@ -247,11 +247,9 @@ class Environment(object):
             findlinks="\n\t".join(findlinks),
             eggs="\n\t".join(eggs),
             zcml="\n\t".join(zcml),
-            relstorage=relstorage,
             develop="\n\t".join(develop),
             profiles="\n\t".join(profiles),
             versions="\n".join(versions),
-            sources="\n".join(sources),
             site=site or "Plone",
             enabled=enabled,
         )
@@ -260,9 +258,15 @@ class Environment(object):
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
         if server:
-            buildout += ZEO_INSTANCE_TEMPLATE.format(
-                zeoaddress=server,
-            )
+            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server)
+
+        # Add RelStorage configuration if needed
+        if relstorage:
+            buildout += RELSTORAGE_TEMPLATE.format(relstorage=relstorage)
+
+        # Add sources configuration if needed
+        if sources:
+            buildout += SOURCES_TEMPLATE.format(sources="\n".join(sources))
 
         with open(self.custom_conf, 'w') as cfile:
             cfile.write(buildout)
@@ -315,10 +319,6 @@ develop += {develop}
 eggs += {eggs}
 zcml += {zcml}
 
-[instance]
-rel-storage =
-  {relstorage}
-
 [plonesite]
 enabled = {enabled}
 site-id = {site}
@@ -326,9 +326,6 @@ profiles += {profiles}
 
 [versions]
 {versions}
-
-[sources]
-{sources}
 """
 
 ZEO_INSTANCE_TEMPLATE = """
@@ -339,6 +336,20 @@ zeo-address = {zeoaddress}
 shared-blob = off
 http-fast-listen = off
 """
+
+RELSTORAGE_TEMPLATE = """
+
+[instance]
+rel-storage =
+  {relstorage}
+"""
+
+SOURCES_TEMPLATE = """
+
+[sources]
+{sources}
+"""
+
 
 def initialize():
     """ Configure Plone instance as ZEO Client

--- a/5.2/5.2.2/python2/docker-initialize.py
+++ b/5.2/5.2.2/python2/docker-initialize.py
@@ -247,7 +247,6 @@ class Environment(object):
             findlinks="\n\t".join(findlinks),
             eggs="\n\t".join(eggs),
             zcml="\n\t".join(zcml),
-            relstorage=relstorage,
             develop="\n\t".join(develop),
             profiles="\n\t".join(profiles),
             versions="\n".join(versions),
@@ -319,10 +318,6 @@ find-links += {findlinks}
 develop += {develop}
 eggs += {eggs}
 zcml += {zcml}
-
-[instance]
-rel-storage =
-  {relstorage}
 
 [plonesite]
 enabled = {enabled}

--- a/5.2/5.2.2/python2/docker-initialize.py
+++ b/5.2/5.2.2/python2/docker-initialize.py
@@ -251,7 +251,6 @@ class Environment(object):
             develop="\n\t".join(develop),
             profiles="\n\t".join(profiles),
             versions="\n".join(versions),
-            sources="\n".join(sources),
             site=site or "Plone",
             enabled=enabled,
         )
@@ -332,9 +331,6 @@ profiles += {profiles}
 
 [versions]
 {versions}
-
-[sources]
-{sources}
 """
 
 ZEO_INSTANCE_TEMPLATE = """

--- a/5.2/5.2.2/python2/docker-initialize.py
+++ b/5.2/5.2.2/python2/docker-initialize.py
@@ -260,9 +260,15 @@ class Environment(object):
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
         if server:
-            buildout += ZEO_INSTANCE_TEMPLATE.format(
-                zeoaddress=server,
-            )
+            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server)
+
+        # Add RelStorage configuration if needed
+        if relstorage:
+            buildout += RELSTORAGE_TEMPLATE.format(relstorage=relstorage)
+
+        # Add sources configuration if needed
+        if sources:
+            buildout += SOURCES_TEMPLATE.format(sources="\n".join(sources))
 
         with open(self.custom_conf, 'w') as cfile:
             cfile.write(buildout)
@@ -339,6 +345,20 @@ zeo-address = {zeoaddress}
 shared-blob = off
 http-fast-listen = off
 """
+
+RELSTORAGE_TEMPLATE = """
+
+[instance]
+rel-storage =
+  {relstorage}
+"""
+
+SOURCES_TEMPLATE = """
+
+[sources]
+{sources}
+"""
+
 
 def initialize():
     """ Configure Plone instance as ZEO Client

--- a/5.2/5.2.2/python36/docker-initialize.py
+++ b/5.2/5.2.2/python36/docker-initialize.py
@@ -247,7 +247,6 @@ class Environment(object):
             findlinks="\n\t".join(findlinks),
             eggs="\n\t".join(eggs),
             zcml="\n\t".join(zcml),
-            relstorage=relstorage,
             develop="\n\t".join(develop),
             profiles="\n\t".join(profiles),
             versions="\n".join(versions),
@@ -319,10 +318,6 @@ find-links += {findlinks}
 develop += {develop}
 eggs += {eggs}
 zcml += {zcml}
-
-[instance]
-rel-storage =
-  {relstorage}
 
 [plonesite]
 enabled = {enabled}

--- a/5.2/5.2.2/python36/docker-initialize.py
+++ b/5.2/5.2.2/python36/docker-initialize.py
@@ -251,7 +251,6 @@ class Environment(object):
             develop="\n\t".join(develop),
             profiles="\n\t".join(profiles),
             versions="\n".join(versions),
-            sources="\n".join(sources),
             site=site or "Plone",
             enabled=enabled,
         )
@@ -332,9 +331,6 @@ profiles += {profiles}
 
 [versions]
 {versions}
-
-[sources]
-{sources}
 """
 
 ZEO_INSTANCE_TEMPLATE = """

--- a/5.2/5.2.2/python36/docker-initialize.py
+++ b/5.2/5.2.2/python36/docker-initialize.py
@@ -260,9 +260,15 @@ class Environment(object):
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
         if server:
-            buildout += ZEO_INSTANCE_TEMPLATE.format(
-                zeoaddress=server,
-            )
+            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server)
+
+        # Add RelStorage configuration if needed
+        if relstorage:
+            buildout += RELSTORAGE_TEMPLATE.format(relstorage=relstorage)
+
+        # Add sources configuration if needed
+        if sources:
+            buildout += SOURCES_TEMPLATE.format(sources="\n".join(sources))
 
         with open(self.custom_conf, 'w') as cfile:
             cfile.write(buildout)
@@ -339,6 +345,20 @@ zeo-address = {zeoaddress}
 shared-blob = off
 http-fast-listen = off
 """
+
+RELSTORAGE_TEMPLATE = """
+
+[instance]
+rel-storage =
+  {relstorage}
+"""
+
+SOURCES_TEMPLATE = """
+
+[sources]
+{sources}
+"""
+
 
 def initialize():
     """ Configure Plone instance as ZEO Client

--- a/5.2/5.2.2/python37/docker-initialize.py
+++ b/5.2/5.2.2/python37/docker-initialize.py
@@ -247,7 +247,6 @@ class Environment(object):
             findlinks="\n\t".join(findlinks),
             eggs="\n\t".join(eggs),
             zcml="\n\t".join(zcml),
-            relstorage=relstorage,
             develop="\n\t".join(develop),
             profiles="\n\t".join(profiles),
             versions="\n".join(versions),
@@ -319,10 +318,6 @@ find-links += {findlinks}
 develop += {develop}
 eggs += {eggs}
 zcml += {zcml}
-
-[instance]
-rel-storage =
-  {relstorage}
 
 [plonesite]
 enabled = {enabled}

--- a/5.2/5.2.2/python37/docker-initialize.py
+++ b/5.2/5.2.2/python37/docker-initialize.py
@@ -251,7 +251,6 @@ class Environment(object):
             develop="\n\t".join(develop),
             profiles="\n\t".join(profiles),
             versions="\n".join(versions),
-            sources="\n".join(sources),
             site=site or "Plone",
             enabled=enabled,
         )
@@ -332,9 +331,6 @@ profiles += {profiles}
 
 [versions]
 {versions}
-
-[sources]
-{sources}
 """
 
 ZEO_INSTANCE_TEMPLATE = """

--- a/5.2/5.2.2/python37/docker-initialize.py
+++ b/5.2/5.2.2/python37/docker-initialize.py
@@ -260,9 +260,15 @@ class Environment(object):
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
         if server:
-            buildout += ZEO_INSTANCE_TEMPLATE.format(
-                zeoaddress=server,
-            )
+            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server)
+
+        # Add RelStorage configuration if needed
+        if relstorage:
+            buildout += RELSTORAGE_TEMPLATE.format(relstorage=relstorage)
+
+        # Add sources configuration if needed
+        if sources:
+            buildout += SOURCES_TEMPLATE.format(sources="\n".join(sources))
 
         with open(self.custom_conf, 'w') as cfile:
             cfile.write(buildout)
@@ -339,6 +345,20 @@ zeo-address = {zeoaddress}
 shared-blob = off
 http-fast-listen = off
 """
+
+RELSTORAGE_TEMPLATE = """
+
+[instance]
+rel-storage =
+  {relstorage}
+"""
+
+SOURCES_TEMPLATE = """
+
+[sources]
+{sources}
+"""
+
 
 def initialize():
     """ Configure Plone instance as ZEO Client

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Enable LDAP/AD support on Plone 5.1
+  [@pnicolli]
 - Only extend develop.cfg when needed
   [@pnicolli]
 - Add LDAP/AD support

--- a/README.md
+++ b/README.md
@@ -10,8 +10,8 @@ We **don't** recommended them for production!
 - Images for Plone 5.x and Plone 4.x
 - Enable add-ons via environment variables
 - Choose between [Debian](https://www.debian.org/) or [Alpine](http://www.alpinelinux.org/) based images
-- Built-in RelStorage support, configurable via environment variables
-- Built-in LDAP/AD support via pas.plugins.ldap
+- Built-in RelStorage support, configurable via environment variables (requires Plone 5.2+)
+- Built-in LDAP/AD support via pas.plugins.ldap (requires Plone 5.1+)
 
 > **NOTE**: **Python 2 based Docker images** are no longer supported by the [Docker Official Images](https://docs.docker.com/docker-hub/official_images/) \
 If you need Python 2, you can use `plone/plone:5-python2` instead of `plone:5-python2`.


### PR DESCRIPTION
This PR extends the latest additions to older versions, whenever possible.

- LDAP support has been added to 5.1.6
- The performance optimization for the startup buildout has been extended to 5.1.6 and 4.3.19.

Furthermore, the custom buildout created in the entrypoint has been changed to make it easier to pass the official library tests. It should be possible to open a PR for the official library by just adding a `find-links += ` line  (mind the blank space after the `=`) to the tests that are already present.