### PR TITLE
Buildout can now extend custom cfg files

### DIFF
--- a/4.3/4.3.19/alpine/docker-initialize.py
+++ b/4.3/4.3.19/alpine/docker-initialize.py
@@ -148,6 +148,11 @@ class Environment(object):
 
         sources = self.env.get("SOURCES", "").strip().split(",")
 
+        buildout_extends = ((develop or sources)
+                            and ["develop.cfg"] or ["buildout.cfg"])
+        extra_extends = self.env.get("BUILDOUT_EXTENDS", "").strip().split()
+        buildout_extends.extend(extra_extends)
+
         # If profiles not provided. Install ADDONS :default profiles
         if not profiles:
             for egg in eggs:
@@ -155,10 +160,11 @@ class Environment(object):
                 profiles.append("%s:default" % base)
 
         enabled = bool(site)
-        if not (eggs or zcml or develop or enabled):
+        if not (eggs or zcml or develop or enabled or extra_extends):
             return
 
         buildout = BUILDOUT_TEMPLATE.format(
+            buildout_extends="\n\t".join(buildout_extends),
             findlinks="\n\t".join(findlinks),
             eggs="\n\t".join(eggs),
             zcml="\n\t".join(zcml),
@@ -223,7 +229,7 @@ CORS_TEMPLATE = """<configure
 
 BUILDOUT_TEMPLATE = """
 [buildout]
-extends = develop.cfg
+extends = {buildout_extends}
 find-links += {findlinks}
 develop += {develop}
 eggs += {eggs}

--- a/4.3/4.3.19/debian/docker-initialize.py
+++ b/4.3/4.3.19/debian/docker-initialize.py
@@ -148,6 +148,11 @@ class Environment(object):
 
         sources = self.env.get("SOURCES", "").strip().split(",")
 
+        buildout_extends = ((develop or sources)
+                            and ["develop.cfg"] or ["buildout.cfg"])
+        extra_extends = self.env.get("BUILDOUT_EXTENDS", "").strip().split()
+        buildout_extends.extend(extra_extends)
+
         # If profiles not provided. Install ADDONS :default profiles
         if not profiles:
             for egg in eggs:
@@ -155,10 +160,11 @@ class Environment(object):
                 profiles.append("%s:default" % base)
 
         enabled = bool(site)
-        if not (eggs or zcml or develop or enabled):
+        if not (eggs or zcml or develop or enabled or extra_extends):
             return
 
         buildout = BUILDOUT_TEMPLATE.format(
+            buildout_extends="\n\t".join(buildout_extends),
             findlinks="\n\t".join(findlinks),
             eggs="\n\t".join(eggs),
             zcml="\n\t".join(zcml),
@@ -223,7 +229,7 @@ CORS_TEMPLATE = """<configure
 
 BUILDOUT_TEMPLATE = """
 [buildout]
-extends = develop.cfg
+extends = {buildout_extends}
 find-links += {findlinks}
 develop += {develop}
 eggs += {eggs}

--- a/5.1/5.1.6/alpine/docker-initialize.py
+++ b/5.1/5.1.6/alpine/docker-initialize.py
@@ -148,6 +148,11 @@ class Environment(object):
 
         sources = self.env.get("SOURCES", "").strip().split(",")
 
+        buildout_extends = ((develop or sources)
+                            and ["develop.cfg"] or ["buildout.cfg"])
+        extra_extends = self.env.get("BUILDOUT_EXTENDS", "").strip().split()
+        buildout_extends.extend(extra_extends)
+
         # If profiles not provided. Install ADDONS :default profiles
         if not profiles:
             for egg in eggs:
@@ -155,10 +160,11 @@ class Environment(object):
                 profiles.append("%s:default" % base)
 
         enabled = bool(site)
-        if not (eggs or zcml or develop or enabled):
+        if not (eggs or zcml or develop or enabled or extra_extends):
             return
 
         buildout = BUILDOUT_TEMPLATE.format(
+            buildout_extends="\n\t".join(buildout_extends),
             findlinks="\n\t".join(findlinks),
             eggs="\n\t".join(eggs),
             zcml="\n\t".join(zcml),
@@ -223,7 +229,7 @@ CORS_TEMPLATE = """<configure
 
 BUILDOUT_TEMPLATE = """
 [buildout]
-extends = develop.cfg
+extends = {buildout_extends}
 find-links += {findlinks}
 develop += {develop}
 eggs += {eggs}

--- a/5.1/5.1.6/debian/docker-initialize.py
+++ b/5.1/5.1.6/debian/docker-initialize.py
@@ -148,6 +148,11 @@ class Environment(object):
 
         sources = self.env.get("SOURCES", "").strip().split(",")
 
+        buildout_extends = ((develop or sources)
+                            and ["develop.cfg"] or ["buildout.cfg"])
+        extra_extends = self.env.get("BUILDOUT_EXTENDS", "").strip().split()
+        buildout_extends.extend(extra_extends)
+
         # If profiles not provided. Install ADDONS :default profiles
         if not profiles:
             for egg in eggs:
@@ -155,10 +160,11 @@ class Environment(object):
                 profiles.append("%s:default" % base)
 
         enabled = bool(site)
-        if not (eggs or zcml or develop or enabled):
+        if not (eggs or zcml or develop or enabled or extra_extends):
             return
 
         buildout = BUILDOUT_TEMPLATE.format(
+            buildout_extends="\n\t".join(buildout_extends),
             findlinks="\n\t".join(findlinks),
             eggs="\n\t".join(eggs),
             zcml="\n\t".join(zcml),
@@ -223,7 +229,7 @@ CORS_TEMPLATE = """<configure
 
 BUILDOUT_TEMPLATE = """
 [buildout]
-extends = develop.cfg
+extends = {buildout_extends}
 find-links += {findlinks}
 develop += {develop}
 eggs += {eggs}

--- a/5.2/5.2.2/alpine/docker-initialize.py
+++ b/5.2/5.2.2/alpine/docker-initialize.py
@@ -230,7 +230,9 @@ class Environment(object):
         relstorage = self.relstorage_conf()
 
         buildout_extends = ((develop or sources)
-                            and "develop.cfg" or "buildout.cfg")
+                            and ["develop.cfg"] or ["buildout.cfg"])
+        extra_extends = self.env.get("BUILDOUT_EXTENDS", "").strip().split()
+        buildout_extends.extend(extra_extends)
 
         # If profiles not provided. Install ADDONS :default profiles
         if not profiles:
@@ -239,11 +241,13 @@ class Environment(object):
                 profiles.append("%s:default" % base)
 
         enabled = bool(site)
-        if not (eggs or zcml or relstorage or develop or enabled):
+        if not (
+            eggs or zcml or relstorage or develop or enabled or extra_extends
+        ):
             return
 
         buildout = BUILDOUT_TEMPLATE.format(
-            buildout_extends=buildout_extends,
+            buildout_extends="\n\t".join(buildout_extends),
             findlinks="\n\t".join(findlinks),
             eggs="\n\t".join(eggs),
             zcml="\n\t".join(zcml),
@@ -309,7 +313,6 @@ CORS_TEMPLATE = """<configure
 
 BUILDOUT_TEMPLATE = """
 [buildout]
-extends = {buildout_extends}
 find-links += {findlinks}
 develop += {develop}
 eggs += {eggs}

--- a/5.2/5.2.2/debian/docker-initialize.py
+++ b/5.2/5.2.2/debian/docker-initialize.py
@@ -230,7 +230,9 @@ class Environment(object):
         relstorage = self.relstorage_conf()
 
         buildout_extends = ((develop or sources)
-                            and "develop.cfg" or "buildout.cfg")
+                            and ["develop.cfg"] or ["buildout.cfg"])
+        extra_extends = self.env.get("BUILDOUT_EXTENDS", "").strip().split()
+        buildout_extends.extend(extra_extends)
 
         # If profiles not provided. Install ADDONS :default profiles
         if not profiles:
@@ -239,11 +241,13 @@ class Environment(object):
                 profiles.append("%s:default" % base)
 
         enabled = bool(site)
-        if not (eggs or zcml or relstorage or develop or enabled):
+        if not (
+            eggs or zcml or relstorage or develop or enabled or extra_extends
+        ):
             return
 
         buildout = BUILDOUT_TEMPLATE.format(
-            buildout_extends=buildout_extends,
+            buildout_extends="\n\t".join(buildout_extends),
             findlinks="\n\t".join(findlinks),
             eggs="\n\t".join(eggs),
             zcml="\n\t".join(zcml),

--- a/5.2/5.2.2/python2/docker-initialize.py
+++ b/5.2/5.2.2/python2/docker-initialize.py
@@ -230,7 +230,9 @@ class Environment(object):
         relstorage = self.relstorage_conf()
 
         buildout_extends = ((develop or sources)
-                            and "develop.cfg" or "buildout.cfg")
+                            and ["develop.cfg"] or ["buildout.cfg"])
+        extra_extends = self.env.get("BUILDOUT_EXTENDS", "").strip().split()
+        buildout_extends.extend(extra_extends)
 
         # If profiles not provided. Install ADDONS :default profiles
         if not profiles:
@@ -239,11 +241,13 @@ class Environment(object):
                 profiles.append("%s:default" % base)
 
         enabled = bool(site)
-        if not (eggs or zcml or relstorage or develop or enabled):
+        if not (
+            eggs or zcml or relstorage or develop or enabled or extra_extends
+        ):
             return
 
         buildout = BUILDOUT_TEMPLATE.format(
-            buildout_extends=buildout_extends,
+            buildout_extends="\n\t".join(buildout_extends),
             findlinks="\n\t".join(findlinks),
             eggs="\n\t".join(eggs),
             zcml="\n\t".join(zcml),

--- a/5.2/5.2.2/python36/docker-initialize.py
+++ b/5.2/5.2.2/python36/docker-initialize.py
@@ -230,7 +230,9 @@ class Environment(object):
         relstorage = self.relstorage_conf()
 
         buildout_extends = ((develop or sources)
-                            and "develop.cfg" or "buildout.cfg")
+                            and ["develop.cfg"] or ["buildout.cfg"])
+        extra_extends = self.env.get("BUILDOUT_EXTENDS", "").strip().split()
+        buildout_extends.extend(extra_extends)
 
         # If profiles not provided. Install ADDONS :default profiles
         if not profiles:
@@ -239,11 +241,13 @@ class Environment(object):
                 profiles.append("%s:default" % base)
 
         enabled = bool(site)
-        if not (eggs or zcml or relstorage or develop or enabled):
+        if not (
+            eggs or zcml or relstorage or develop or enabled or extra_extends
+        ):
             return
 
         buildout = BUILDOUT_TEMPLATE.format(
-            buildout_extends=buildout_extends,
+            buildout_extends="\n\t".join(buildout_extends),
             findlinks="\n\t".join(findlinks),
             eggs="\n\t".join(eggs),
             zcml="\n\t".join(zcml),

--- a/5.2/5.2.2/python37/docker-initialize.py
+++ b/5.2/5.2.2/python37/docker-initialize.py
@@ -230,7 +230,9 @@ class Environment(object):
         relstorage = self.relstorage_conf()
 
         buildout_extends = ((develop or sources)
-                            and "develop.cfg" or "buildout.cfg")
+                            and ["develop.cfg"] or ["buildout.cfg"])
+        extra_extends = self.env.get("BUILDOUT_EXTENDS", "").strip().split()
+        buildout_extends.extend(extra_extends)
 
         # If profiles not provided. Install ADDONS :default profiles
         if not profiles:
@@ -239,11 +241,13 @@ class Environment(object):
                 profiles.append("%s:default" % base)
 
         enabled = bool(site)
-        if not (eggs or zcml or relstorage or develop or enabled):
+        if not (
+            eggs or zcml or relstorage or develop or enabled or extra_extends
+        ):
             return
 
         buildout = BUILDOUT_TEMPLATE.format(
-            buildout_extends=buildout_extends,
+            buildout_extends="\n\t".join(buildout_extends),
             findlinks="\n\t".join(findlinks),
             eggs="\n\t".join(eggs),
             zcml="\n\t".join(zcml),

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,7 @@
 # Changelog
 
+- Allow buildout to extend custom files
+  [@pnicolli]
 - Only extend develop.cfg when needed
   [@pnicolli]
 - Add LDAP/AD support

--- a/README.md
+++ b/README.md
@@ -138,6 +138,7 @@ curl -H 'Accept: application/json' http://localhost:8080/plone
 * `PLONE_PROFILES, PROFILES` - GenericSetup profiles to include when `SITE` environment provided.
 * `PLONE_ZCML`, `ZCML` - Include custom Plone add-ons ZCML files
 * `PLONE_DEVELOP`, `DEVELOP` - Develop new or existing Plone add-ons
+* `BUILDOUT_EXTENDS` - Add configuration files that buildout should extend
 * `FIND_LINKS` - Add custom `find-links` to the buildout configuration
 * `SOURCES` - Add custom `sources` to the buildout configuration
 


### PR DESCRIPTION
Draft implementation.
This allows to add custom cfg files to extend to the buildout that is run at container startup.