### PR TITLE
Fix zeo shared blob

### DIFF
--- a/4.3/4.3.19/alpine/docker-initialize.py
+++ b/4.3/4.3.19/alpine/docker-initialize.py
@@ -182,9 +182,10 @@ class Environment(object):
         # If we need to create a plonesite and we have a zeo setup
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
+        shared_blob_dir=self.env.get("ZEO_SHARED_BLOB_DIR", "off")
         if server:
-            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server)
-
+            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server,
+                                                     shared_blob_dir=shared_blob_dir)
         # Add sources configuration if needed
         if sources:
             buildout += SOURCES_TEMPLATE.format(sources="\n".join(sources))
@@ -254,7 +255,7 @@ ZEO_INSTANCE_TEMPLATE = """
 [instance]
 zeo-client = true
 zeo-address = {zeoaddress}
-shared-blob = off
+shared-blob = {shared_blob_dir}
 http-fast-listen = off
 """
 

--- a/4.3/4.3.19/debian/docker-initialize.py
+++ b/4.3/4.3.19/debian/docker-initialize.py
@@ -182,8 +182,10 @@ class Environment(object):
         # If we need to create a plonesite and we have a zeo setup
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
+        shared_blob_dir=self.env.get("ZEO_SHARED_BLOB_DIR", "off")
         if server:
-            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server)
+            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server,
+                                                     shared_blob_dir=shared_blob_dir)
 
         # Add sources configuration if needed
         if sources:
@@ -254,7 +256,7 @@ ZEO_INSTANCE_TEMPLATE = """
 [instance]
 zeo-client = true
 zeo-address = {zeoaddress}
-shared-blob = off
+shared-blob = {shared_blob_dir}
 http-fast-listen = off
 """
 

--- a/5.1/5.1.6/alpine/docker-initialize.py
+++ b/5.1/5.1.6/alpine/docker-initialize.py
@@ -182,8 +182,10 @@ class Environment(object):
         # If we need to create a plonesite and we have a zeo setup
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
+        shared_blob_dir=self.env.get("ZEO_SHARED_BLOB_DIR", "off")
         if server:
-            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server)
+            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server,
+                                                     shared_blob_dir=shared_blob_dir)
 
         # Add sources configuration if needed
         if sources:
@@ -254,7 +256,7 @@ ZEO_INSTANCE_TEMPLATE = """
 [instance]
 zeo-client = true
 zeo-address = {zeoaddress}
-shared-blob = off
+shared-blob = {shared_blob_dir}
 http-fast-listen = off
 """
 

--- a/5.1/5.1.6/debian/docker-initialize.py
+++ b/5.1/5.1.6/debian/docker-initialize.py
@@ -182,8 +182,10 @@ class Environment(object):
         # If we need to create a plonesite and we have a zeo setup
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
+        shared_blob_dir=self.env.get("ZEO_SHARED_BLOB_DIR", "off")
         if server:
-            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server)
+            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server,
+                                                     shared_blob_dir=shared_blob_dir)
 
         # Add sources configuration if needed
         if sources:
@@ -254,7 +256,7 @@ ZEO_INSTANCE_TEMPLATE = """
 [instance]
 zeo-client = true
 zeo-address = {zeoaddress}
-shared-blob = off
+shared-blob = {shared_blob_dir}
 http-fast-listen = off
 """
 

--- a/5.2/5.2.0/alpine/docker-initialize.py
+++ b/5.2/5.2.0/alpine/docker-initialize.py
@@ -167,9 +167,11 @@ class Environment(object):
         # If we need to create a plonesite and we have a zeo setup
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
+        shared_blob_dir=self.env.get("ZEO_SHARED_BLOB_DIR", "off")
         if server:
             buildout += ZEO_INSTANCE_TEMPLATE.format(
                 zeoaddress=server,
+                shared_blob_dir=shared_blob_dir,
             )
 
         with open(self.custom_conf, 'w') as cfile:
@@ -236,7 +238,7 @@ ZEO_INSTANCE_TEMPLATE = """
 [instance]
 zeo-client = true
 zeo-address = {zeoaddress}
-shared-blob = off
+shared-blob = {shared_blob_dir}
 http-fast-listen = off
 """
 

--- a/5.2/5.2.0/debian/docker-initialize.py
+++ b/5.2/5.2.0/debian/docker-initialize.py
@@ -167,9 +167,11 @@ class Environment(object):
         # If we need to create a plonesite and we have a zeo setup
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
+        shared_blob_dir=self.env.get("ZEO_SHARED_BLOB_DIR", "off")
         if server:
             buildout += ZEO_INSTANCE_TEMPLATE.format(
                 zeoaddress=server,
+                shared_blob_dir=shared_blob_dir,
             )
 
         with open(self.custom_conf, 'w') as cfile:
@@ -236,7 +238,7 @@ ZEO_INSTANCE_TEMPLATE = """
 [instance]
 zeo-client = true
 zeo-address = {zeoaddress}
-shared-blob = off
+shared-blob = {shared_blob_dir}
 http-fast-listen = off
 """
 

--- a/5.2/5.2.0/python2/docker-initialize.py
+++ b/5.2/5.2.0/python2/docker-initialize.py
@@ -167,9 +167,11 @@ class Environment(object):
         # If we need to create a plonesite and we have a zeo setup
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
+        shared_blob_dir=self.env.get("ZEO_SHARED_BLOB_DIR", "off")
         if server:
             buildout += ZEO_INSTANCE_TEMPLATE.format(
                 zeoaddress=server,
+                shared_blob_dir=shared_blob_dir,
             )
 
         with open(self.custom_conf, 'w') as cfile:
@@ -236,7 +238,7 @@ ZEO_INSTANCE_TEMPLATE = """
 [instance]
 zeo-client = true
 zeo-address = {zeoaddress}
-shared-blob = off
+shared-blob = {shared_blob_dir}
 http-fast-listen = off
 """
 

--- a/5.2/5.2.1/alpine/docker-initialize.py
+++ b/5.2/5.2.1/alpine/docker-initialize.py
@@ -167,9 +167,11 @@ class Environment(object):
         # If we need to create a plonesite and we have a zeo setup
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
+        shared_blob_dir=self.env.get("ZEO_SHARED_BLOB_DIR", "off")
         if server:
             buildout += ZEO_INSTANCE_TEMPLATE.format(
                 zeoaddress=server,
+                shared_blob_dir=shared_blob_dir,
             )
 
         with open(self.custom_conf, 'w') as cfile:
@@ -236,7 +238,7 @@ ZEO_INSTANCE_TEMPLATE = """
 [instance]
 zeo-client = true
 zeo-address = {zeoaddress}
-shared-blob = off
+shared-blob = {shared_blob_dir}
 http-fast-listen = off
 """
 

--- a/5.2/5.2.1/debian/docker-initialize.py
+++ b/5.2/5.2.1/debian/docker-initialize.py
@@ -167,9 +167,11 @@ class Environment(object):
         # If we need to create a plonesite and we have a zeo setup
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
+        shared_blob_dir=self.env.get("ZEO_SHARED_BLOB_DIR", "off")
         if server:
             buildout += ZEO_INSTANCE_TEMPLATE.format(
                 zeoaddress=server,
+                shared_blob_dir=shared_blob_dir
             )
 
         with open(self.custom_conf, 'w') as cfile:
@@ -236,7 +238,7 @@ ZEO_INSTANCE_TEMPLATE = """
 [instance]
 zeo-client = true
 zeo-address = {zeoaddress}
-shared-blob = off
+shared-blob = {shared_blob_dir}
 http-fast-listen = off
 """
 

--- a/5.2/5.2.1/python2/docker-initialize.py
+++ b/5.2/5.2.1/python2/docker-initialize.py
@@ -167,9 +167,11 @@ class Environment(object):
         # If we need to create a plonesite and we have a zeo setup
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
+        shared_blob_dir=self.env.get("ZEO_SHARED_BLOB_DIR", "off")
         if server:
             buildout += ZEO_INSTANCE_TEMPLATE.format(
                 zeoaddress=server,
+                shared_blob_dir=shared_blob_dir
             )
 
         with open(self.custom_conf, 'w') as cfile:
@@ -236,7 +238,7 @@ ZEO_INSTANCE_TEMPLATE = """
 [instance]
 zeo-client = true
 zeo-address = {zeoaddress}
-shared-blob = off
+shared-blob = {shared_blob_dir}
 http-fast-listen = off
 """
 

--- a/5.2/5.2.2/alpine/docker-initialize.py
+++ b/5.2/5.2.2/alpine/docker-initialize.py
@@ -261,8 +261,11 @@ class Environment(object):
         # If we need to create a plonesite and we have a zeo setup
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
+        shared_blob_dir=self.env.get("ZEO_SHARED_BLOB_DIR", "off")
         if server:
-            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server)
+            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server,
+                                                     shared_blob_dir=shared_blob_dir)
+
 
         # Add RelStorage configuration if needed
         if relstorage:
@@ -336,7 +339,7 @@ ZEO_INSTANCE_TEMPLATE = """
 [instance]
 zeo-client = true
 zeo-address = {zeoaddress}
-shared-blob = off
+shared-blob = {shared_blob_dir}
 http-fast-listen = off
 """
 

--- a/5.2/5.2.2/debian/docker-initialize.py
+++ b/5.2/5.2.2/debian/docker-initialize.py
@@ -261,8 +261,10 @@ class Environment(object):
         # If we need to create a plonesite and we have a zeo setup
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
+        shared_blob_dir=self.env.get("ZEO_SHARED_BLOB_DIR", "off")
         if server:
-            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server)
+            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server,
+                                                     shared_blob_dir=shared_blob_dir)
 
         # Add RelStorage configuration if needed
         if relstorage:
@@ -337,7 +339,7 @@ ZEO_INSTANCE_TEMPLATE = """
 [instance]
 zeo-client = true
 zeo-address = {zeoaddress}
-shared-blob = off
+shared-blob = {shared_blob_dir}
 http-fast-listen = off
 """
 

--- a/5.2/5.2.2/python2/docker-initialize.py
+++ b/5.2/5.2.2/python2/docker-initialize.py
@@ -261,8 +261,10 @@ class Environment(object):
         # If we need to create a plonesite and we have a zeo setup
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
+        shared_blob_dir=self.env.get("ZEO_SHARED_BLOB_DIR", "off")
         if server:
-            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server)
+            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server,
+                                                     shared_blob_dir=shared_blob_dir)
 
         # Add RelStorage configuration if needed
         if relstorage:
@@ -337,7 +339,7 @@ ZEO_INSTANCE_TEMPLATE = """
 [instance]
 zeo-client = true
 zeo-address = {zeoaddress}
-shared-blob = off
+shared-blob = {shared_blob_dir}
 http-fast-listen = off
 """
 

--- a/5.2/5.2.2/python36/docker-initialize.py
+++ b/5.2/5.2.2/python36/docker-initialize.py
@@ -261,8 +261,10 @@ class Environment(object):
         # If we need to create a plonesite and we have a zeo setup
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
+        shared_blob_dir=self.env.get("ZEO_SHARED_BLOB_DIR", "off")
         if server:
-            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server)
+            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server,
+                                                     shared_blob_dir=shared_blob_dir)
 
         # Add RelStorage configuration if needed
         if relstorage:
@@ -337,7 +339,7 @@ ZEO_INSTANCE_TEMPLATE = """
 [instance]
 zeo-client = true
 zeo-address = {zeoaddress}
-shared-blob = off
+shared-blob = {shared_blob_dir}
 http-fast-listen = off
 """
 

--- a/5.2/5.2.2/python37/docker-initialize.py
+++ b/5.2/5.2.2/python37/docker-initialize.py
@@ -261,8 +261,10 @@ class Environment(object):
         # If we need to create a plonesite and we have a zeo setup
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
+        shared_blob_dir=self.env.get("ZEO_SHARED_BLOB_DIR", "off")
         if server:
-            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server)
+            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server,
+                                                     shared_blob_dir=shared_blob_dir)
 
         # Add RelStorage configuration if needed
         if relstorage:
@@ -337,7 +339,7 @@ ZEO_INSTANCE_TEMPLATE = """
 [instance]
 zeo-client = true
 zeo-address = {zeoaddress}
-shared-blob = off
+shared-blob = {shared_blob_dir}
 http-fast-listen = off
 """
 

--- a/5.2/5.2.4/alpine/docker-initialize.py
+++ b/5.2/5.2.4/alpine/docker-initialize.py
@@ -261,8 +261,10 @@ class Environment(object):
         # If we need to create a plonesite and we have a zeo setup
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
+        shared_blob_dir=self.env.get("ZEO_SHARED_BLOB_DIR", "off")
         if server:
-            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server)
+            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server,
+                                                     shared_blob_dir=shared_blob_dir)
 
         # Add RelStorage configuration if needed
         if relstorage:
@@ -337,7 +339,7 @@ ZEO_INSTANCE_TEMPLATE = """
 [instance]
 zeo-client = true
 zeo-address = {zeoaddress}
-shared-blob = off
+shared-blob = {shared_blob_dir}
 http-fast-listen = off
 """
 

--- a/5.2/5.2.4/debian/docker-initialize.py
+++ b/5.2/5.2.4/debian/docker-initialize.py
@@ -261,8 +261,10 @@ class Environment(object):
         # If we need to create a plonesite and we have a zeo setup
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
+        shared_blob_dir=self.env.get("ZEO_SHARED_BLOB_DIR", "off")
         if server:
-            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server)
+            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server,
+                                                     shared_blob_dir=shared_blob_dir)
 
         # Add RelStorage configuration if needed
         if relstorage:
@@ -337,7 +339,7 @@ ZEO_INSTANCE_TEMPLATE = """
 [instance]
 zeo-client = true
 zeo-address = {zeoaddress}
-shared-blob = off
+shared-blob = {shared_blob_dir}
 http-fast-listen = off
 """
 

--- a/5.2/5.2.4/python2/docker-initialize.py
+++ b/5.2/5.2.4/python2/docker-initialize.py
@@ -261,8 +261,10 @@ class Environment(object):
         # If we need to create a plonesite and we have a zeo setup
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
+        shared_blob_dir=self.env.get("ZEO_SHARED_BLOB_DIR", "off")
         if server:
-            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server)
+            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server,
+                                                     shared_blob_dir=shared_blob_dir)
 
         # Add RelStorage configuration if needed
         if relstorage:
@@ -337,7 +339,7 @@ ZEO_INSTANCE_TEMPLATE = """
 [instance]
 zeo-client = true
 zeo-address = {zeoaddress}
-shared-blob = off
+shared-blob = {shared_blob_dir}
 http-fast-listen = off
 """
 

--- a/5.2/5.2.4/python36/docker-initialize.py
+++ b/5.2/5.2.4/python36/docker-initialize.py
@@ -261,8 +261,10 @@ class Environment(object):
         # If we need to create a plonesite and we have a zeo setup
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
+        shared_blob_dir=self.env.get("ZEO_SHARED_BLOB_DIR", "off")
         if server:
-            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server)
+            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server,
+                                                     shared_blob_dir=shared_blob_dir)
 
         # Add RelStorage configuration if needed
         if relstorage:
@@ -337,7 +339,7 @@ ZEO_INSTANCE_TEMPLATE = """
 [instance]
 zeo-client = true
 zeo-address = {zeoaddress}
-shared-blob = off
+shared-blob = {shared_blob_dir}
 http-fast-listen = off
 """
 

--- a/5.2/5.2.4/python37/docker-initialize.py
+++ b/5.2/5.2.4/python37/docker-initialize.py
@@ -261,8 +261,10 @@ class Environment(object):
         # If we need to create a plonesite and we have a zeo setup
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
+        shared_blob_dir=self.env.get("ZEO_SHARED_BLOB_DIR", "off")
         if server:
-            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server)
+            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server,
+                                                     shared_blob_dir=shared_blob_dir)
 
         # Add RelStorage configuration if needed
         if relstorage:
@@ -337,7 +339,7 @@ ZEO_INSTANCE_TEMPLATE = """
 [instance]
 zeo-client = true
 zeo-address = {zeoaddress}
-shared-blob = off
+shared-blob = {shared_blob_dir}
 http-fast-listen = off
 """
 

--- a/5.2/5.2.5/alpine/docker-initialize.py
+++ b/5.2/5.2.5/alpine/docker-initialize.py
@@ -263,8 +263,10 @@ class Environment(object):
         # If we need to create a plonesite and we have a zeo setup
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
+        shared_blob_dir=self.env.get("ZEO_SHARED_BLOB_DIR", "off")
         if server:
-            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server)
+            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server,
+                                                     shared_blob_dir=shared_blob_dir)
 
         # Add RelStorage configuration if needed
         if relstorage:
@@ -343,7 +345,7 @@ ZEO_INSTANCE_TEMPLATE = """
 [instance]
 zeo-client = true
 zeo-address = {zeoaddress}
-shared-blob = off
+shared-blob = {shared_blob_dir}
 http-fast-listen = off
 """
 

--- a/5.2/5.2.5/debian/docker-initialize.py
+++ b/5.2/5.2.5/debian/docker-initialize.py
@@ -263,8 +263,10 @@ class Environment(object):
         # If we need to create a plonesite and we have a zeo setup
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
+        shared_blob_dir=self.env.get("ZEO_SHARED_BLOB_DIR", "off")
         if server:
-            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server)
+            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server,
+                                                     shared_blob_dir=shared_blob_dir)
 
         # Add RelStorage configuration if needed
         if relstorage:
@@ -343,7 +345,7 @@ ZEO_INSTANCE_TEMPLATE = """
 [instance]
 zeo-client = true
 zeo-address = {zeoaddress}
-shared-blob = off
+shared-blob = {shared_blob_dir}
 http-fast-listen = off
 """
 

--- a/5.2/5.2.5/python2/docker-initialize.py
+++ b/5.2/5.2.5/python2/docker-initialize.py
@@ -263,8 +263,10 @@ class Environment(object):
         # If we need to create a plonesite and we have a zeo setup
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
+        shared_blob_dir=self.env.get("ZEO_SHARED_BLOB_DIR", "off")
         if server:
-            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server)
+            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server,
+                                                     shared_blob_dir=shared_blob_dir)
 
         # Add RelStorage configuration if needed
         if relstorage:
@@ -343,7 +345,7 @@ ZEO_INSTANCE_TEMPLATE = """
 [instance]
 zeo-client = true
 zeo-address = {zeoaddress}
-shared-blob = off
+shared-blob = {shared_blob_dir}
 http-fast-listen = off
 """
 

--- a/5.2/5.2.5/python36/docker-initialize.py
+++ b/5.2/5.2.5/python36/docker-initialize.py
@@ -263,8 +263,10 @@ class Environment(object):
         # If we need to create a plonesite and we have a zeo setup
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
+        shared_blob_dir=self.env.get("ZEO_SHARED_BLOB_DIR", "off")
         if server:
-            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server)
+            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server,
+                                                     shared_blob_dir=shared_blob_dir)
 
         # Add RelStorage configuration if needed
         if relstorage:
@@ -343,7 +345,7 @@ ZEO_INSTANCE_TEMPLATE = """
 [instance]
 zeo-client = true
 zeo-address = {zeoaddress}
-shared-blob = off
+shared-blob = {shared_blob_dir}
 http-fast-listen = off
 """
 

--- a/5.2/5.2.5/python37/docker-initialize.py
+++ b/5.2/5.2.5/python37/docker-initialize.py
@@ -263,8 +263,10 @@ class Environment(object):
         # If we need to create a plonesite and we have a zeo setup
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
+        shared_blob_dir=self.env.get("ZEO_SHARED_BLOB_DIR", "off")
         if server:
-            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server)
+            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server,
+                                                     shared_blob_dir=shared_blob_dir)
 
         # Add RelStorage configuration if needed
         if relstorage:
@@ -343,7 +345,7 @@ ZEO_INSTANCE_TEMPLATE = """
 [instance]
 zeo-client = true
 zeo-address = {zeoaddress}
-shared-blob = off
+shared-blob = {shared_blob_dir}
 http-fast-listen = off
 """
 

--- a/5.2/5.2.6/alpine/docker-initialize.py
+++ b/5.2/5.2.6/alpine/docker-initialize.py
@@ -263,8 +263,11 @@ class Environment(object):
         # If we need to create a plonesite and we have a zeo setup
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
+        shared_blob_dir=self.env.get("ZEO_SHARED_BLOB_DIR", "off")
+
         if server:
-            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server)
+            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server,
+                                                     shared_blob_dir=shared_blob_dir)
 
         # Add RelStorage configuration if needed
         if relstorage:
@@ -343,7 +346,7 @@ ZEO_INSTANCE_TEMPLATE = """
 [instance]
 zeo-client = true
 zeo-address = {zeoaddress}
-shared-blob = off
+shared-blob = {shared_blob_dir}
 http-fast-listen = off
 """
 

--- a/5.2/5.2.6/debian/docker-initialize.py
+++ b/5.2/5.2.6/debian/docker-initialize.py
@@ -263,8 +263,10 @@ class Environment(object):
         # If we need to create a plonesite and we have a zeo setup
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
+        shared_blob_dir=self.env.get("ZEO_SHARED_BLOB_DIR", "off")
         if server:
-            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server)
+            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server,
+                                                     shared_blob_dir=shared_blob_dir)
 
         # Add RelStorage configuration if needed
         if relstorage:
@@ -343,7 +345,7 @@ ZEO_INSTANCE_TEMPLATE = """
 [instance]
 zeo-client = true
 zeo-address = {zeoaddress}
-shared-blob = off
+shared-blob = {shared_blob_dir}
 http-fast-listen = off
 """
 

--- a/5.2/5.2.6/python2/docker-initialize.py
+++ b/5.2/5.2.6/python2/docker-initialize.py
@@ -263,8 +263,10 @@ class Environment(object):
         # If we need to create a plonesite and we have a zeo setup
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
+        shared_blob_dir=self.env.get("ZEO_SHARED_BLOB_DIR", "off")
         if server:
-            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server)
+            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server,
+                                                     shared_blob_dir=shared_blob_dir)
 
         # Add RelStorage configuration if needed
         if relstorage:
@@ -343,7 +345,7 @@ ZEO_INSTANCE_TEMPLATE = """
 [instance]
 zeo-client = true
 zeo-address = {zeoaddress}
-shared-blob = off
+shared-blob = {shared_blob_dir}
 http-fast-listen = off
 """
 

--- a/5.2/5.2.6/python36/docker-initialize.py
+++ b/5.2/5.2.6/python36/docker-initialize.py
@@ -263,8 +263,11 @@ class Environment(object):
         # If we need to create a plonesite and we have a zeo setup
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
+        shared_blob_dir=self.env.get("ZEO_SHARED_BLOB_DIR", "off")
+
         if server:
-            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server)
+            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server,
+                                                     shared_blob_dir=shared_blob_dir)
 
         # Add RelStorage configuration if needed
         if relstorage:
@@ -343,7 +346,7 @@ ZEO_INSTANCE_TEMPLATE = """
 [instance]
 zeo-client = true
 zeo-address = {zeoaddress}
-shared-blob = off
+shared-blob = {shared_blob_dir}
 http-fast-listen = off
 """
 

--- a/5.2/5.2.6/python37/docker-initialize.py
+++ b/5.2/5.2.6/python37/docker-initialize.py
@@ -263,8 +263,11 @@ class Environment(object):
         # If we need to create a plonesite and we have a zeo setup
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
+        shared_blob_dir=self.env.get("ZEO_SHARED_BLOB_DIR", "off")
+
         if server:
-            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server)
+            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server,
+                                                     shared_blob_dir=shared_blob_dir)
 
         # Add RelStorage configuration if needed
         if relstorage:
@@ -343,7 +346,7 @@ ZEO_INSTANCE_TEMPLATE = """
 [instance]
 zeo-client = true
 zeo-address = {zeoaddress}
-shared-blob = off
+shared-blob = {shared_blob_dir}
 http-fast-listen = off
 """
 

--- a/5.2/5.2.7/alpine/docker-initialize.py
+++ b/5.2/5.2.7/alpine/docker-initialize.py
@@ -263,8 +263,11 @@ class Environment(object):
         # If we need to create a plonesite and we have a zeo setup
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
+        shared_blob_dir=self.env.get("ZEO_SHARED_BLOB_DIR", "off")
+
         if server:
-            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server)
+            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server,
+                                                     shared_blob_dir=shared_blob_dir)
 
         # Add RelStorage configuration if needed
         if relstorage:
@@ -343,7 +346,7 @@ ZEO_INSTANCE_TEMPLATE = """
 [instance]
 zeo-client = true
 zeo-address = {zeoaddress}
-shared-blob = off
+shared-blob = {shared_blob_dir}
 http-fast-listen = off
 """
 

--- a/5.2/5.2.7/debian/docker-initialize.py
+++ b/5.2/5.2.7/debian/docker-initialize.py
@@ -263,8 +263,11 @@ class Environment(object):
         # If we need to create a plonesite and we have a zeo setup
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
+        shared_blob_dir=self.env.get("ZEO_SHARED_BLOB_DIR", "off")
+
         if server:
-            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server)
+            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server,
+                                                     shared_blob_dir=shared_blob_dir)
 
         # Add RelStorage configuration if needed
         if relstorage:
@@ -343,7 +346,8 @@ ZEO_INSTANCE_TEMPLATE = """
 [instance]
 zeo-client = true
 zeo-address = {zeoaddress}
-shared-blob = off
+shared-blob = {shared_blob_dir}
+
 http-fast-listen = off
 """
 

--- a/5.2/5.2.7/python2/docker-initialize.py
+++ b/5.2/5.2.7/python2/docker-initialize.py
@@ -263,8 +263,11 @@ class Environment(object):
         # If we need to create a plonesite and we have a zeo setup
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
+        shared_blob_dir=self.env.get("ZEO_SHARED_BLOB_DIR", "off")
+
         if server:
-            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server)
+            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server,
+                                                     shared_blob_dir=shared_blob_dir)
 
         # Add RelStorage configuration if needed
         if relstorage:
@@ -343,7 +346,7 @@ ZEO_INSTANCE_TEMPLATE = """
 [instance]
 zeo-client = true
 zeo-address = {zeoaddress}
-shared-blob = off
+shared-blob = {shared_blob_dir}
 http-fast-listen = off
 """
 

--- a/5.2/5.2.7/python36/docker-initialize.py
+++ b/5.2/5.2.7/python36/docker-initialize.py
@@ -263,8 +263,12 @@ class Environment(object):
         # If we need to create a plonesite and we have a zeo setup
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
+        shared_blob_dir=self.env.get("ZEO_SHARED_BLOB_DIR", "off")
+
         if server:
-            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server)
+            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server,
+                                                     shared_blob_dir=shared_blob_dir)
+
 
         # Add RelStorage configuration if needed
         if relstorage:
@@ -343,7 +347,7 @@ ZEO_INSTANCE_TEMPLATE = """
 [instance]
 zeo-client = true
 zeo-address = {zeoaddress}
-shared-blob = off
+shared-blob = {shared_blob_dir}
 http-fast-listen = off
 """
 

--- a/5.2/5.2.7/python37/docker-initialize.py
+++ b/5.2/5.2.7/python37/docker-initialize.py
@@ -263,8 +263,10 @@ class Environment(object):
         # If we need to create a plonesite and we have a zeo setup
         # configure collective.recipe.plonesite properly
         server = self.env.get("ZEO_ADDRESS", None)
+        shared_blob_dir=self.env.get("ZEO_SHARED_BLOB_DIR", "off")
         if server:
-            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server)
+            buildout += ZEO_INSTANCE_TEMPLATE.format(zeoaddress=server,
+                                                     shared_blob_dir=shared_blob_dir)
 
         # Add RelStorage configuration if needed
         if relstorage:
@@ -343,7 +345,7 @@ ZEO_INSTANCE_TEMPLATE = """
 [instance]
 zeo-client = true
 zeo-address = {zeoaddress}
-shared-blob = off
+shared-blob = {shared_blob_dir}
 http-fast-listen = off
 """
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,5 +1,6 @@
 # Changelog
-
+- fix shared-blob-dir always off
+  [@sauzher]
 - Default logging to stdout/stderr by default from 5.2.5. Setting env FILE_LOGGING to revert to previous behavior.
   [@mamico]
 - Allow buildout to extend custom files


### PR DESCRIPTION
This fix the fix `shared-blob-dir` parameter always `off` even wher using `ZEO_SHARED_BLOB_DIR=on` in the environment due to buildout compilation that overwrites it.

