### PR TITLE
Add the Plone 4.1 legacy image

### DIFF
--- a/.github/workflows/legacy-build.yml
+++ b/.github/workflows/legacy-build.yml
@@ -37,6 +37,9 @@ jobs:
               - 'legacy/demo/**'
               - 'legacy/Makefile'
               - '.github/workflows/legacy-build.yml'
+            v4.1:
+              - *shared
+              - 'legacy/4.1/**'
             v4.2:
               - *shared
               - 'legacy/4.2/**'
@@ -49,7 +52,7 @@ jobs:
           BUILD_ALL: ${{ github.event_name != 'pull_request' }}
         run: |
           # Implemented versions; append when a new directory lands.
-          ALL='["4.2"]'
+          ALL='["4.1","4.2"]'
           if [ "${BUILD_ALL}" = "true" ]; then
             VERSIONS="${ALL}"
           else

--- a/.github/workflows/legacy-build.yml
+++ b/.github/workflows/legacy-build.yml
@@ -61,8 +61,18 @@ jobs:
           echo "versions=${VERSIONS}" >> "${GITHUB_OUTPUT}"
           echo "building: ${VERSIONS}"
 
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - name: make lint
+        working-directory: legacy
+        run: make lint
+
   build:
-    needs: changes
+    needs:
+      - changes
+      - lint
     if: needs.changes.outputs.versions != '[]'
     runs-on: ubuntu-latest
     strategy:
@@ -167,10 +177,33 @@ jobs:
             echo "::notice::DOCKERHUB_USERNAME/DOCKERHUB_TOKEN not set - pushed to GHCR only."
           fi
 
-  lint:
+  # Syncs the Docker Hub description from the root README, so the Hub page
+  # cannot drift from what this repository actually publishes.
+  description:
+    needs:
+      - build
+    if: github.ref == 'refs/heads/main' && github.event_name != 'pull_request'
     runs-on: ubuntu-latest
+    env:
+      DOCKERHUB_IMAGE: plone/plone
+      # Secrets cannot be referenced from an `if:` condition, so the presence
+      # check is hoisted into a job-level env var and the step gates on that
+      # instead. Without the credentials this job does nothing rather than
+      # failing, matching how the push job skips Hub.
+      HAS_DOCKERHUB: ${{ secrets.DOCKERHUB_USERNAME != '' && secrets.DOCKERHUB_TOKEN != '' }}
     steps:
       - uses: actions/checkout@v7
-      - name: make lint
-        working-directory: legacy
-        run: make lint
+      - name: Docker Hub Description
+        uses: peter-evans/dockerhub-description@v5
+        if: env.HAS_DOCKERHUB == 'true'
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+          repository: ${{ env.DOCKERHUB_IMAGE }}
+          short-description: ${{ github.event.repository.description }}
+          # The README links to paths in this repository relative to its root
+          # (legacy/, 5.2/5.2.14/debian/Dockerfile, ...). On Docker Hub those
+          # would resolve against hub.docker.com and 404, so let the action
+          # rewrite them to absolute GitHub URLs.
+          enable-url-completion: true
+          readme-filepath: ./README.md

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
 # Changelog
+- Add Plone 4.1 image to the legacy matrix. Refs #182
+  [@ericof]
 - Add Plone 4.2 image, the first of the legacy matrix (Plone 1.0 - 4.2). For content extraction, migration and archaeology only. Refs #180
   [@ericof]
 - fix shared-blob-dir always off

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ If you need Python 2, you can use `plone/plone:5-python2` instead of `plone:5-py
 Newest to oldest. For the 4.3 - 5.2 series only the **latest point release** is
 listed; earlier point releases remain in the repository and on Docker Hub.
 
-| Plone | Python | Variant | Built from | Docker Hub tags |
+| Plone | Python | Variant | Built from | Published tags |
 |---|---|---|---|---|
 | 5.2.14 | 3.8 | Debian | [`5.2/5.2.14/debian/Dockerfile`](5.2/5.2.14/debian/Dockerfile) | `latest`, `5`, `5.2`, `5.2.14`, `python38`, `5-python38`, `5.2-python38`, `5.2.14-python38` |
 | 5.2.14 | 3.8 | Alpine | [`5.2/5.2.14/alpine/Dockerfile`](5.2/5.2.14/alpine/Dockerfile) | *not published* |
@@ -44,15 +44,32 @@ listed; earlier point releases remain in the repository and on Docker Hub.
 | 5.0.8 | 2.7 | Alpine | [`5.0/5.0.8/alpine/Dockerfile`](5.0/5.0.8/alpine/Dockerfile) | *not published* |
 | 4.3.19 | 2.7 | Debian | [`4.3/4.3.19/debian/Dockerfile`](4.3/4.3.19/debian/Dockerfile) | `4`, `4.3`, `4.3.19` |
 | 4.3.19 | 2.7 | Alpine | [`4.3/4.3.19/alpine/Dockerfile`](4.3/4.3.19/alpine/Dockerfile) | `4-alpine`, `4.3-alpine`, `4.3.19-alpine` |
-| 4.2.6 | 2.7.18 | Debian *(legacy)* | [`legacy/4.2/Dockerfile`](legacy/4.2/Dockerfile) | *not yet published* |
+| 4.2.6 | 2.7.18 | Debian *(legacy)* | [`legacy/4.2/Dockerfile`](legacy/4.2/Dockerfile) | `4.2`, `4.2.6`, `4.2-demo`, `4.2.6-demo` |
 | 4.1.6 | 2.6.9 | Debian *(legacy)* | [`legacy/4.1/Dockerfile`](legacy/4.1/Dockerfile) | *not yet published* |
+
+### Where the tags live
+
+The two halves of the table publish to **different places**, and the tag names
+alone do not say which:
+
+| Rows | Registry | Pull with |
+|---|---|---|
+| 4.3 - 5.2 | the official `plone` image | `docker pull plone:5.2.14` |
+| `legacy/` | `plone/plone` and GHCR | `docker pull plone/plone:4.2`<br>`docker pull ghcr.io/plone/plone.docker:4.2` |
+
+`plone/plone` also carries its own 4.3 - 5.2 tags, but those are a mirror last
+pushed in **March 2021** and are older than the official image's. For anything
+4.3 and above, prefer `plone:<tag>`.
+
+Each legacy series publishes four tags — the full version and the series, each
+with a `-demo` counterpart that ships a Plone site already created.
 
 The 4.3 - 5.2 images take Python from an upstream `python:*` base image. The
 `legacy/` images build the interpreter from source, because no usable base
 image exists for Python 2.3 - 2.7 of that vintage.
 
 Floating tags such as `5.2-alpine`, `5.2-python2` and `5.2-python37` exist on
-Docker Hub but point at **earlier** point releases than 5.2.14 — the 5.2.14
+the official image but point at **earlier** point releases than 5.2.14 — the 5.2.14
 roll published only the Python 3.8 variant.
 
 ## Legacy images (Plone 1.0 - 4.2)

--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ listed; earlier point releases remain in the repository and on Docker Hub.
 | 4.3.19 | 2.7 | Debian | [`4.3/4.3.19/debian/Dockerfile`](4.3/4.3.19/debian/Dockerfile) | `4`, `4.3`, `4.3.19` |
 | 4.3.19 | 2.7 | Alpine | [`4.3/4.3.19/alpine/Dockerfile`](4.3/4.3.19/alpine/Dockerfile) | `4-alpine`, `4.3-alpine`, `4.3.19-alpine` |
 | 4.2.6 | 2.7.18 | Debian *(legacy)* | [`legacy/4.2/Dockerfile`](legacy/4.2/Dockerfile) | *not yet published* |
+| 4.1.6 | 2.6.9 | Debian *(legacy)* | [`legacy/4.1/Dockerfile`](legacy/4.1/Dockerfile) | *not yet published* |
 
 The 4.3 - 5.2 images take Python from an upstream `python:*` base image. The
 `legacy/` images build the interpreter from source, because no usable base

--- a/legacy/4.1/Dockerfile
+++ b/legacy/4.1/Dockerfile
@@ -1,0 +1,134 @@
+# syntax=docker/dockerfile:1
+#
+# Plone 4.1.x — buildout era (Zope 2.13.15 / Python 2.6.9)
+#
+# Strategy:
+#   Stage 1 (fetch): modern userland downloads everything (old TLS never touches network)
+#   Stage 2 (build): Python 2.6 + PIL, then an OFFLINE buildout from the
+#                    UnifiedInstaller's bundled buildout-cache
+#   Stage 3 (runtime): slim image, non-root, /data volume, port 8080
+#
+# [V 2026-08-20] 4.1.6 is both the final 4.1.x release and the last
+# UnifiedInstaller, so this row needs no compromise.
+#
+# [V 2026-08-20] Plone 4 packages Zope as an EGG (Zope2-2.13.15), not the
+# configure+make tarball used through 3.x. The buildout handles that itself,
+# which is the main reason these images are built from the UnifiedInstaller
+# rather than assembled by hand.
+#
+# NOT FOR PRODUCTION. This stack has known, unpatched security issues.
+# Intended for content extraction, migration, and archaeology only.
+
+ARG PYTHON_VERSION=2.6.9
+ARG PLONE_VERSION=4.1.6
+ARG PIL_VERSION=1.1.6
+ARG ZOPE_VERSION=2.13.15
+
+ARG PYTHON_URL=https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz
+ARG PLONE_URL=https://launchpad.net/plone/4.1/${PLONE_VERSION}/+download/Plone-${PLONE_VERSION}-UnifiedInstaller.tgz
+ARG PIL_URL=https://dist.plone.org/thirdparty/PIL-${PIL_VERSION}.tar.gz
+
+# ---------------------------------------------------------------------------
+# Stage 1: fetch — modern TLS, nothing else
+# ---------------------------------------------------------------------------
+FROM debian:bookworm-slim AS fetch
+ARG PYTHON_URL
+ARG PLONE_URL
+ARG PIL_URL
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates curl \
+ && rm -rf /var/lib/apt/lists/*
+WORKDIR /dist
+# --retry: Launchpad intermittently answers 503 under load (observed repeatedly
+# on 2026-08-20), and a transient failure here wastes the whole build.
+RUN curl -fSL --retry 5 --retry-delay 5 "${PYTHON_URL}" -o python.tgz \
+ && curl -fSL --retry 5 --retry-delay 5 "${PLONE_URL}"  -o installer.tgz \
+ && curl -fSL --retry 5 --retry-delay 5 "${PIL_URL}"    -o pil.tar.gz
+
+# ---------------------------------------------------------------------------
+# Stage 2a: pybuild — the interpreter only (gate G1)
+# ---------------------------------------------------------------------------
+FROM debian:bookworm AS pybuild
+ARG PYTHON_VERSION
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      gcc make libc6-dev zlib1g-dev libcrypt-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=fetch /dist /dist
+COPY shared/build-python2.sh /usr/local/bin/build-python2.sh
+
+RUN build-python2.sh /dist/python.tgz "${PYTHON_VERSION}" /opt/python2.6
+
+# ---------------------------------------------------------------------------
+# Stage 2b: build — PIL, then the offline buildout.
+# ---------------------------------------------------------------------------
+FROM pybuild AS build
+ARG PLONE_VERSION
+ARG PIL_VERSION
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      libjpeg62-turbo-dev bzip2 libxml2-dev libxslt1-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+# [V 2026-08-20] libxml2-dev/libxslt1-dev are required from 4.1 on: the
+# buildout builds lxml from source (2.2.8 here, 2.3.6 in 4.2) and fails with
+#   src/lxml/etree_defs.h:9: fatal error: libxml/xmlversion.h: No such file
+#   ERROR: xslt-config: not found
+# 4.0.9 does not pull lxml at all, which is why it builds without them.
+#
+# NOTE: this is NOT the "old lxml vs modern libxml2" hot spot. That one bites
+# at libxml2 >= 2.12; bookworm ships 2.9.14, so the distro headers are period-
+# appropriate enough and no static libxml2 build is needed. Revisit if the
+# base image ever moves to trixie.
+COPY shared/build-pil.sh /usr/local/bin/build-pil.sh
+RUN build-pil.sh /dist/pil.tar.gz "${PIL_VERSION}" /opt/python2.6/bin/python2.6
+
+COPY shared/build-plone-buildout.sh /usr/local/bin/build-plone-buildout.sh
+RUN build-plone-buildout.sh /dist/installer.tgz "${PLONE_VERSION}" \
+      /opt/python2.6/bin/python2.6 /app
+
+# ---------------------------------------------------------------------------
+# Stage 3: runtime
+# ---------------------------------------------------------------------------
+FROM debian:bookworm-slim
+ARG PLONE_VERSION
+ARG ZOPE_VERSION
+ARG PYTHON_VERSION
+
+LABEL org.opencontainers.image.title="Plone ${PLONE_VERSION} (legacy)" \
+      org.opencontainers.image.description="Plone ${PLONE_VERSION} on Zope ${ZOPE_VERSION} / Python ${PYTHON_VERSION}. Migration and content-extraction use only — NOT for production." \
+      org.opencontainers.image.vendor="Simples Consultoria"
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      zlib1g libcrypt1 libjpeg62-turbo libxml2 libxslt1.1 \
+ && rm -rf /var/lib/apt/lists/* \
+ && useradd --system -m -d /app -U -u 500 plone \
+ && mkdir -p /data \
+ && chown -R plone:plone /data
+
+COPY --from=build --chown=plone:plone /opt/python2.6 /opt/python2.6
+COPY --from=build --chown=plone:plone /app /app
+COPY --chown=plone:plone shared/docker-entrypoint-buildout.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+COPY --chown=plone:plone shared/upgrade-plone.py /app/upgrade-plone.py
+COPY --chown=plone:plone shared/configure-zeo.sh /app/configure-zeo.sh
+RUN chmod +x /app/configure-zeo.sh
+
+ENV INSTANCE_HOME=/app/instance \
+    PYTHON=/opt/python2.6/bin/python2.6 \
+    ZOPE_HTTP_PORT=8080
+
+VOLUME /data
+EXPOSE 8080
+WORKDIR /app/instance
+USER plone
+
+HEALTHCHECK --interval=10s --timeout=5s --start-period=180s --retries=6 \
+  CMD ["/opt/python2.6/bin/python2.6", "-c", "import urllib; urllib.urlopen('http://127.0.0.1:8080/')"]
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["start"]

--- a/legacy/4.1/README.md
+++ b/legacy/4.1/README.md
@@ -1,0 +1,58 @@
+# Plone 4.1 legacy image
+
+Plone 4.1.6 on Zope 2.13.15 / Python 2.6.9. Buildout era.
+
+**Not for production.** This stack has known, unpatched vulnerabilities. The
+image exists for content extraction, migration rehearsal, and historical
+inspection.
+
+## Usage
+
+```sh
+docker build -f 4.1/Dockerfile -t plone-legacy:4.1.6 .
+docker run -d -p 8080:8080 -e ADMIN_PASSWORD=secret \
+    -v plone41-data:/data plone-legacy:4.1.6
+```
+
+| | |
+|---|---|
+| Port | 8080 (`ZOPE_HTTP_PORT` to change) |
+| Volume | `/data` (`filestorage/Data.fs`, `log/`) |
+| User | `plone` (uid 500) |
+| Env | `ADMIN_USER`, `ADMIN_PASSWORD` (first run only) |
+
+## How it is built
+
+From the Launchpad **UnifiedInstaller**, whose
+`packages/buildout-cache.tar.bz2` is a complete offline cache of every egg and
+distribution including Zope itself. Buildout runs fully offline, so the old
+toolchain never has to negotiate modern TLS. See
+`shared/build-plone-buildout.sh`.
+
+## Validated facts / hypotheses
+
+- **[V 2026-08-20]** 4.1.6 is **both** the final 4.1.x release and the last
+  UnifiedInstaller, so this row needs no compromise — unlike 4.0 and 4.2.
+- **[V 2026-08-20]** **lxml appears here, and it is not the hot spot we were
+  warned about.** The buildout builds lxml 2.2.8 from source and failed with
+
+  ```
+  src/lxml/etree_defs.h:9: fatal error: libxml/xmlversion.h: No such file
+  ERROR: xslt-config: not found
+  ```
+
+  That is simply missing `libxml2-dev` / `libxslt1-dev`, now installed in the
+  build stage. The recorded hot spot — "old lxml does not compile against
+  libxml2 >= 2.12" — does **not** bite: bookworm ships libxml2 **2.9.14**, so no
+  static libxml2 build (`z3c.recipe.staticlxml`) is needed. Revisit if the base
+  image ever moves to trixie.
+- **[V 2026-08-20]** Zope is 2.13.15, from the installer’s own pins.
+- **[V 2026-08-20]** Zero product import/install errors; a site is created and
+  renders ~19.7 kB. Passes twice.
+
+## Smoke test (CI gate)
+
+```sh
+make test-4.1
+SMOKE_CREATE_SITE=1 make test-4.1
+```

--- a/legacy/Makefile
+++ b/legacy/Makefile
@@ -14,7 +14,7 @@ PLATFORM ?= linux/amd64
 # the matrix in README.md, and the ALL list in
 # ../.github/workflows/legacy-build.yml. One series lands per pull request;
 # append here as each one is ported.
-SERIES := 4.2
+SERIES := 4.1 4.2
 
 # Builder used for the -demo images, which MUST be a `docker`-driver one:
 # demo/Dockerfile's FROM reads the base image out of the local image store, and
@@ -40,6 +40,9 @@ DEMO_TEST_PASSWORD ?= smoke-not-admin
 # [V 2026-08-20] 4.2.6, not the final 4.2.7: 4.2.7 has no UnifiedInstaller
 # published, and the installer is what carries the offline buildout-cache
 # these images are built from.
+# [V 2026-08-20] 4.1.6 is both the final 4.1.x release and the last
+# UnifiedInstaller published for the series, so this row needs no compromise.
+FULL_VERSION_4.1 := 4.1.6
 FULL_VERSION_4.2 := 4.2.6
 
 .PHONY: help

--- a/legacy/README.md
+++ b/legacy/README.md
@@ -13,9 +13,10 @@ They exist for content extraction, migration rehearsal, and archaeology.
 | Dir  | Plone | Zope    | Python | Install  | JSON         | Status |
 |------|-------|---------|--------|----------|--------------|--------|
 | 4.2  | 4.2.6 | 2.13.21 | 2.7.18 | buildout | stdlib `json` | **done** |
+| 4.1  | 4.1.6 | 2.13.15 | 2.6.9  | buildout | stdlib `json` | **done** |
 
 The matrix extends down to Plone 1.0. One series lands per pull request; the
-remaining ten follow this one. When adding a series, keep four places in sync:
+remaining nine follow these. When adding a series, keep four places in sync:
 the directory, the table above, `SERIES` and `FULL_VERSION_*` in the
 [`Makefile`](Makefile), and the paths-filter list plus `ALL` in
 [`../.github/workflows/legacy-build.yml`](../.github/workflows/legacy-build.yml).


### PR DESCRIPTION
Adds the **Plone 4.1** image — the second series of the legacy matrix, after #180 established the `legacy/` subtree, the shared scripts and `legacy-build.yml`.

These images are for **content extraction, migration rehearsal and archaeology only**. The stacks have known, unpatched security issues and must never be exposed.

Closes #182
Closes #179

## The cheapest series in the matrix

4.1 needs **no new shared scripts** — it uses the same six as 4.2, all of which landed with that image. The Dockerfile differs only in version constants and the interpreter path:

| | 4.2 | 4.1 |
|---|---|---|
| Plone | 4.2.6 | **4.1.6** |
| Zope | 2.13.21 | **2.13.15** |
| Python | 2.7.18 | **2.6.9** |
| Interpreter path | `/opt/python2.7` | `/opt/python2.6` |
| JSON | stdlib `json` | stdlib `json` (2.6 has it) |

**4.1.6 needs no version compromise.** It is both the final 4.1.x release and the last UnifiedInstaller published for the series — unlike 4.0 (no installer past 4.0.9) and 4.2 (none past 4.2.6), where the buildable version is behind the final one.

Source: `https://launchpad.net/plone/4.1/4.1.6/+download/Plone-4.1.6-UnifiedInstaller.tgz`

### Verification

| Check | Result |
|---|---|
| `make lint` — hadolint ×3, shellcheck ×8, yq | pass |
| Base smoke test (`SMOKE_CREATE_SITE=1`) | pass, 7/7 gates |
| `-demo` build + smoke test | pass, 6/6 gates |

The smoke gate asserts product load with no import errors, JSON round-trip, site creation, that the site root renders real Plone markup, and that the Sunburst theme profile applied. The `-demo` gate additionally asserts the site is already present on first start and that the build-time password stops authenticating once `ADMIN_PASSWORD` is set.

**One gap, same as 4.2:** the local `docker build` reused cached layers from the source repository, so the cold build happens for the first time in CI.

## CI: lint now gates the build

`lint` runs before `build`, which now depends on it. Previously a lint failure still cost a full cold build of every series in the matrix before anything reported.

## CI: Docker Hub description sync

A new `description` job syncs the Docker Hub description for `plone/plone` from the root README after a successful build, so the Hub page cannot drift from what the repository actually publishes.

Three details there are deliberate:

- **`repository` is passed as an Actions expression.** A shell-style `${VAR}` in a `with:` block is *not* interpolated — it reaches the action as that literal text and fails its `<namespace>/<name>` format check.
- **`enable-url-completion` is on.** The README links to paths relative to the repository root; on Docker Hub those would resolve against `hub.docker.com` and 404.
- **The branch/event gate sits on the job, not the step**, so pull requests do not start a runner just to skip its one step. The credentials check stays on the step, because secrets cannot be read from a job-level `if:`.

### This closes #179

#179 asks for the Docker Hub description to stop telling people to migrate away, which now contradicts the legacy tags published under that namespace. The sync job fixes that at the source: the description is generated from the root README on every push to `main`, so it cannot drift again.

Worth recording that there are two distinct pages, and this reaches one of them:

| Page | Controlled by | Reached here |
|---|---|---|
| `plone/plone` | this repository | **yes** — the new job |
| official `plone` (`docker pull plone:5.2.14`) | `docker-library/docs` | no |

The official image's page is edited by a PR against `docker-library/docs`, not from here. If that page also needs updating, it is separate work against that repository.

## Also in this PR

The 4.2 row in the root README now names its published tags instead of saying *not yet published*. The first `legacy build` run published `4.2`, `4.2.6`, `4.2-demo` and `4.2.6-demo` to **both** `plone/plone` and `ghcr.io/plone/plone.docker` — so the dual-registry push works and the Docker Hub credentials are in place.

Added a short section explaining **where the tags live**, because one column cannot say it: the 4.3 – 5.2 rows list tags on the *official* `plone` image, while the legacy rows publish to `plone/plone` and GHCR. `plone/plone` also carries its own 4.3 – 5.2 tags, but those are a mirror last pushed in March 2021 and are older than the official image's — a genuinely easy trap. The column is renamed from "Docker Hub tags" to "Published tags" for the same reason.

## Follow-ups

- Nine series remain, one PR each: #183 (4.0), #184 (3.3), #185 (3.2), #186 (3.1), #187 (3.0), #194 (2.5), #195 (2.1), #196 (2.0), #197 (1.0).
- `legacy/README.md` still shows only the local `plone-legacy:4.2` tags in its quick start, not the published `plone/plone:4.2`.
