### PR TITLE
Add the Plone 4.0 legacy image

### DIFF
--- a/.github/workflows/legacy-build.yml
+++ b/.github/workflows/legacy-build.yml
@@ -37,6 +37,9 @@ jobs:
               - 'legacy/demo/**'
               - 'legacy/Makefile'
               - '.github/workflows/legacy-build.yml'
+            v4.0:
+              - *shared
+              - 'legacy/4.0/**'
             v4.1:
               - *shared
               - 'legacy/4.1/**'
@@ -52,7 +55,7 @@ jobs:
           BUILD_ALL: ${{ github.event_name != 'pull_request' }}
         run: |
           # Implemented versions; append when a new directory lands.
-          ALL='["4.1","4.2"]'
+          ALL='["4.0","4.1","4.2"]'
           if [ "${BUILD_ALL}" = "true" ]; then
             VERSIONS="${ALL}"
           else

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
 # Changelog
+- Add Plone 4.0 image to the legacy matrix. Refs #183
+  [@ericof]
 - Add Plone 4.1 image to the legacy matrix. Refs #182
   [@ericof]
 - Add Plone 4.2 image, the first of the legacy matrix (Plone 1.0 - 4.2). For content extraction, migration and archaeology only. Refs #180

--- a/README.md
+++ b/README.md
@@ -45,7 +45,8 @@ listed; earlier point releases remain in the repository and on Docker Hub.
 | 4.3.19 | 2.7 | Debian | [`4.3/4.3.19/debian/Dockerfile`](4.3/4.3.19/debian/Dockerfile) | `4`, `4.3`, `4.3.19` |
 | 4.3.19 | 2.7 | Alpine | [`4.3/4.3.19/alpine/Dockerfile`](4.3/4.3.19/alpine/Dockerfile) | `4-alpine`, `4.3-alpine`, `4.3.19-alpine` |
 | 4.2.6 | 2.7.18 | Debian *(legacy)* | [`legacy/4.2/Dockerfile`](legacy/4.2/Dockerfile) | `4.2`, `4.2.6`, `4.2-demo`, `4.2.6-demo` |
-| 4.1.6 | 2.6.9 | Debian *(legacy)* | [`legacy/4.1/Dockerfile`](legacy/4.1/Dockerfile) | *not yet published* |
+| 4.1.6 | 2.6.9 | Debian *(legacy)* | [`legacy/4.1/Dockerfile`](legacy/4.1/Dockerfile) | `4.1`, `4.1.6`, `4.1-demo`, `4.1.6-demo` |
+| 4.0.9 | 2.6.9 | Debian *(legacy)* | [`legacy/4.0/Dockerfile`](legacy/4.0/Dockerfile) | `4.0`, `4.0.9`, `4.0-demo`, `4.0.9-demo` |
 
 ### Where the tags live
 

--- a/legacy/4.0/Dockerfile
+++ b/legacy/4.0/Dockerfile
@@ -1,0 +1,124 @@
+# syntax=docker/dockerfile:1
+#
+# Plone 4.0.x — buildout era (Zope 2.12.19 / Python 2.6.9)
+#
+# Strategy:
+#   Stage 1 (fetch): modern userland downloads everything (old TLS never touches network)
+#   Stage 2 (build): Python 2.6 + PIL, then an OFFLINE buildout from the
+#                    UnifiedInstaller's bundled buildout-cache
+#   Stage 3 (runtime): slim image, non-root, /data volume, port 8080
+#
+# [V 2026-08-20] 4.0.9, NOT 4.0.10. 4.0.10 is the final 4.0.x release and its
+# egg set exists at dist.plone.org/release/4.0.10/, but Launchpad has no
+# UnifiedInstaller past 4.0.9 — and the installer is what carries the offline
+# buildout-cache these images depend on.
+#
+# [V 2026-08-20] Plone 4 packages Zope as an EGG (Zope2-2.12.19), not the
+# configure+make tarball used through 3.x. The buildout handles that itself,
+# which is the main reason these images are built from the UnifiedInstaller
+# rather than assembled by hand.
+#
+# NOT FOR PRODUCTION. This stack has known, unpatched security issues.
+# Intended for content extraction, migration, and archaeology only.
+
+ARG PYTHON_VERSION=2.6.9
+ARG PLONE_VERSION=4.0.9
+ARG PIL_VERSION=1.1.6
+ARG ZOPE_VERSION=2.12.19
+
+ARG PYTHON_URL=https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz
+ARG PLONE_URL=https://launchpad.net/plone/4.0/${PLONE_VERSION}/+download/Plone-${PLONE_VERSION}-UnifiedInstaller.tgz
+ARG PIL_URL=https://dist.plone.org/thirdparty/PIL-${PIL_VERSION}.tar.gz
+
+# ---------------------------------------------------------------------------
+# Stage 1: fetch — modern TLS, nothing else
+# ---------------------------------------------------------------------------
+FROM debian:bookworm-slim AS fetch
+ARG PYTHON_URL
+ARG PLONE_URL
+ARG PIL_URL
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates curl \
+ && rm -rf /var/lib/apt/lists/*
+WORKDIR /dist
+# --retry: Launchpad intermittently answers 503 under load (observed repeatedly
+# on 2026-08-20), and a transient failure here wastes the whole build.
+RUN curl -fSL --retry 5 --retry-delay 5 "${PYTHON_URL}" -o python.tgz \
+ && curl -fSL --retry 5 --retry-delay 5 "${PLONE_URL}"  -o installer.tgz \
+ && curl -fSL --retry 5 --retry-delay 5 "${PIL_URL}"    -o pil.tar.gz
+
+# ---------------------------------------------------------------------------
+# Stage 2a: pybuild — the interpreter only (gate G1)
+# ---------------------------------------------------------------------------
+FROM debian:bookworm AS pybuild
+ARG PYTHON_VERSION
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      gcc make libc6-dev zlib1g-dev libcrypt-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=fetch /dist /dist
+COPY shared/build-python2.sh /usr/local/bin/build-python2.sh
+
+RUN build-python2.sh /dist/python.tgz "${PYTHON_VERSION}" /opt/python2.6
+
+# ---------------------------------------------------------------------------
+# Stage 2b: build — PIL, then the offline buildout.
+# ---------------------------------------------------------------------------
+FROM pybuild AS build
+ARG PLONE_VERSION
+ARG PIL_VERSION
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends libjpeg62-turbo-dev bzip2 \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY shared/build-pil.sh /usr/local/bin/build-pil.sh
+RUN build-pil.sh /dist/pil.tar.gz "${PIL_VERSION}" /opt/python2.6/bin/python2.6
+
+COPY shared/build-plone-buildout.sh /usr/local/bin/build-plone-buildout.sh
+RUN build-plone-buildout.sh /dist/installer.tgz "${PLONE_VERSION}" \
+      /opt/python2.6/bin/python2.6 /app
+
+# ---------------------------------------------------------------------------
+# Stage 3: runtime
+# ---------------------------------------------------------------------------
+FROM debian:bookworm-slim
+ARG PLONE_VERSION
+ARG ZOPE_VERSION
+ARG PYTHON_VERSION
+
+LABEL org.opencontainers.image.title="Plone ${PLONE_VERSION} (legacy)" \
+      org.opencontainers.image.description="Plone ${PLONE_VERSION} on Zope ${ZOPE_VERSION} / Python ${PYTHON_VERSION}. Migration and content-extraction use only — NOT for production." \
+      org.opencontainers.image.vendor="Simples Consultoria"
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends zlib1g libcrypt1 libjpeg62-turbo \
+ && rm -rf /var/lib/apt/lists/* \
+ && useradd --system -m -d /app -U -u 500 plone \
+ && mkdir -p /data \
+ && chown -R plone:plone /data
+
+COPY --from=build --chown=plone:plone /opt/python2.6 /opt/python2.6
+COPY --from=build --chown=plone:plone /app /app
+COPY --chown=plone:plone shared/docker-entrypoint-buildout.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+COPY --chown=plone:plone shared/upgrade-plone.py /app/upgrade-plone.py
+COPY --chown=plone:plone shared/configure-zeo.sh /app/configure-zeo.sh
+RUN chmod +x /app/configure-zeo.sh
+
+ENV INSTANCE_HOME=/app/instance \
+    PYTHON=/opt/python2.6/bin/python2.6 \
+    ZOPE_HTTP_PORT=8080
+
+VOLUME /data
+EXPOSE 8080
+WORKDIR /app/instance
+USER plone
+
+HEALTHCHECK --interval=10s --timeout=5s --start-period=180s --retries=6 \
+  CMD ["/opt/python2.6/bin/python2.6", "-c", "import urllib; urllib.urlopen('http://127.0.0.1:8080/')"]
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["start"]

--- a/legacy/4.0/README.md
+++ b/legacy/4.0/README.md
@@ -1,0 +1,59 @@
+# Plone 4.0 legacy image
+
+Plone 4.0.9 on Zope 2.12.19 / Python 2.6.9. Buildout era.
+
+**Not for production.** This stack has known, unpatched vulnerabilities. The
+image exists for content extraction, migration rehearsal, and historical
+inspection.
+
+## Usage
+
+```sh
+docker build -f 4.0/Dockerfile -t plone-legacy:4.0.9 .
+docker run -d -p 8080:8080 -e ADMIN_PASSWORD=secret \
+    -v plone40-data:/data plone-legacy:4.0.9
+```
+
+| | |
+|---|---|
+| Port | 8080 (`ZOPE_HTTP_PORT` to change) |
+| Volume | `/data` (`filestorage/Data.fs`, `log/`) |
+| User | `plone` (uid 500) |
+| Env | `ADMIN_USER`, `ADMIN_PASSWORD` (first run only) |
+
+## How it is built
+
+From the Launchpad **UnifiedInstaller**, whose
+`packages/buildout-cache.tar.bz2` is a complete offline cache of every egg and
+distribution including Zope itself. Buildout runs fully offline, so the old
+toolchain never has to negotiate modern TLS. See
+`shared/build-plone-buildout.sh`.
+
+## Validated facts / hypotheses
+
+- **[V 2026-08-20]** **4.0.9, not 4.0.10.** 4.0.10 is the final 4.0.x release and
+  its complete egg set is published at `dist.plone.org/release/4.0.10/`, but
+  Launchpad has **no UnifiedInstaller past 4.0.9** — and the installer is what
+  carries the offline `buildout-cache`. Building 4.0.10 would mean hand-writing a
+  buildout against the release directory; that is a separate piece of work.
+- **[V 2026-08-20]** Zope is **2.12.19**, read from the installer’s own
+  `zope_versions.cfg` after an initial guess of 2.12.20 (taken from the 4.0.10
+  release dir) proved wrong.
+- **[V 2026-08-20]** **Plone 4 packages Zope as an egg** (`Zope2-2.12.19.zip` in
+  `downloads/dist/`), not the `configure && make` tarball used through 3.x. It is
+  built during buildout, which is the main argument for driving the vendor
+  installer rather than assembling an instance by hand.
+- **[V 2026-08-20]** Python **2.6.9**. The cached eggs are all `-py2.6.egg`, so
+  the interpreter minor version is not a free choice. `build-python2.sh` needed
+  capability detection to handle it — see the 4.2 README.
+- **[V 2026-08-20]** 4.0.9 does **not** pull lxml, which is why it builds without
+  `libxml2-dev`. 4.1 and 4.2 do.
+- **[V 2026-08-20]** Zero product import/install errors; a site is created and
+  renders ~19 kB carrying the Plone `generator` meta tag. Passes twice.
+
+## Smoke test (CI gate)
+
+```sh
+make test-4.0
+SMOKE_CREATE_SITE=1 make test-4.0
+```

--- a/legacy/Makefile
+++ b/legacy/Makefile
@@ -14,7 +14,7 @@ PLATFORM ?= linux/amd64
 # the matrix in README.md, and the ALL list in
 # ../.github/workflows/legacy-build.yml. One series lands per pull request;
 # append here as each one is ported.
-SERIES := 4.1 4.2
+SERIES := 4.0 4.1 4.2
 
 # Builder used for the -demo images, which MUST be a `docker`-driver one:
 # demo/Dockerfile's FROM reads the base image out of the local image store, and
@@ -42,6 +42,11 @@ DEMO_TEST_PASSWORD ?= smoke-not-admin
 # these images are built from.
 # [V 2026-08-20] 4.1.6 is both the final 4.1.x release and the last
 # UnifiedInstaller published for the series, so this row needs no compromise.
+# [V 2026-08-20] 4.0.9, not 4.0.10: 4.0.10 is the final release and its egg
+# set exists at dist.plone.org/release/4.0.10/, but Launchpad published no
+# UnifiedInstaller past 4.0.9 — and the installer is what carries the offline
+# buildout-cache these images are built from.
+FULL_VERSION_4.0 := 4.0.9
 FULL_VERSION_4.1 := 4.1.6
 FULL_VERSION_4.2 := 4.2.6
 

--- a/legacy/README.md
+++ b/legacy/README.md
@@ -14,9 +14,10 @@ They exist for content extraction, migration rehearsal, and archaeology.
 |------|-------|---------|--------|----------|--------------|--------|
 | 4.2  | 4.2.6 | 2.13.21 | 2.7.18 | buildout | stdlib `json` | **done** |
 | 4.1  | 4.1.6 | 2.13.15 | 2.6.9  | buildout | stdlib `json` | **done** |
+| 4.0  | 4.0.9 | 2.12.19 | 2.6.9  | buildout | stdlib `json` | **done** |
 
 The matrix extends down to Plone 1.0. One series lands per pull request; the
-remaining nine follow these. When adding a series, keep four places in sync:
+remaining eight follow these. When adding a series, keep four places in sync:
 the directory, the table above, `SERIES` and `FULL_VERSION_*` in the
 [`Makefile`](Makefile), and the paths-filter list plus `ALL` in
 [`../.github/workflows/legacy-build.yml`](../.github/workflows/legacy-build.yml).


### PR DESCRIPTION
Adds the **Plone 4.0** image — the third series of the legacy matrix, after #180 established the `legacy/` subtree, the shared scripts and `legacy-build.yml`, and #182 added 4.1.

These images are for **content extraction, migration rehearsal and archaeology only**. The stacks have known, unpatched security issues and must never be exposed.

Closes #183

## What differs from 4.1

4.0 needs **no new shared scripts** — it uses the same set as 4.1 and 4.2, and every file it pulls from `shared/` and `demo/` is byte-identical to its counterpart in the source repository. The Dockerfile differs in the version constants and in one build dependency:

| | 4.1 | 4.0 |
|---|---|---|
| Plone | 4.1.6 | **4.0.9** |
| Zope | 2.13.15 | **2.12.19** |
| Python | 2.6.9 | 2.6.9 |
| lxml | 2.2.8, built from source | **none — not pulled at all** |
| Build deps | `+ libxml2-dev`, `libxslt1-dev` | neither needed |
| Runtime deps | `+ libxml2`, `libxslt1.1` | neither needed |
| JSON | stdlib `json` | stdlib `json` (2.6 has it) |

Both versions were read out of the built image rather than assumed: `Plone-4.0.9-py2.6.egg` and `Zope2-2.12.19-py2.6-linux-x86_64.egg`.

### 4.0.9, not the final 4.0.10

4.0.10 is the last 4.0.x release and its complete egg set is published at `dist.plone.org/release/4.0.10/`, but **Launchpad has no UnifiedInstaller past 4.0.9** — and the installer is what carries the offline `buildout-cache` these images build from. Reaching 4.0.10 would mean hand-writing a buildout against the release directory; that is separate work.

This is the same shape of compromise as 4.2 (none past 4.2.6). 4.1 remains the only series so far that needs none.

Source: `https://launchpad.net/plone/4.0/4.0.9/+download/Plone-4.0.9-UnifiedInstaller.tgz`

## Verification

| Check | Result |
|---|---|
| `make lint` — hadolint ×4, shellcheck ×8, yq | pass |
| Base smoke test (`SMOKE_CREATE_SITE=1`) | pass, 7/7 gates |
| `-demo` build + `make test-demo-4.0` | pass, 6/6 gates |
| `make -n` on all four targets, GNU Make 3.81 | correct, incl. the stem trap |

The smoke gate asserts product load with no import errors, JSON round-trip, site creation, that the site root renders real Plone markup (19,862 bytes carrying the `generator` meta tag), and that the Sunburst theme profile applied. The `-demo` gate additionally asserts the site is already present on first start and that the build-time password stops authenticating once `ADMIN_PASSWORD` is set.

The make dry-run matters because macOS ships GNU Make **3.81**, which resolves overlapping pattern rules by definition order rather than shortest stem: `test-demo-4.0` correctly expands to `plone-legacy:4.0.9-demo` rather than to an empty tag.

**One gap, same as 4.1 and 4.2:** the local `docker build` was 100% cache hits off the layers built in the source repository, so the cold build happens for the first time in CI. That still proves the context/path rewrite — a wrong `COPY shared/…` errors rather than cache-hits — but not a cold build.

## Published tags

The root README's three legacy rows now all name their tags, and the phrase *not yet published* is gone from the file.

- **4.1** — recorded after the fact. The first `legacy build` on `main` pushed `4.1`, `4.1.6`, `4.1-demo` and `4.1.6-demo` to **both** `plone/plone` and `ghcr.io/plone/plone.docker`; verified against both registries.
- **4.0** — named ahead of publication, deliberately. The `description` job runs `needs: build` on pushes to `main`, so the sequence at merge is *push the tags, then sync README.md to the Docker Hub page*. A row reading *not yet published* would be false at the exact moment Hub receives it.

That is a change of practice from #182, where 4.2's tags were recorded in a separate follow-up commit — but the description-sync job did not exist yet at that point; it landed one commit later.

## Follow-ups

- Eight series remain, one PR each: #184 (3.3), #185 (3.2), #186 (3.1), #187 (3.0), #194 (2.5), #195 (2.1), #196 (2.0), #197 (1.0).
- `legacy/README.md` still shows only the local `plone-legacy:4.2` tags in its quick start, not the published `plone/plone:4.2`. Carried over from #182.
- `legacy/README.md`'s prose is still written around 4.2 alone — the "JSON" section explains only Python 2.7's stdlib `json`, and the era paragraph names only 4.2, though 4.0 and 4.1 are equally buildout-era with a stdlib `json` on 2.6.
