### PR TITLE
Add the Plone 3.3 legacy image

### DIFF
--- a/.github/workflows/legacy-build.yml
+++ b/.github/workflows/legacy-build.yml
@@ -37,6 +37,9 @@ jobs:
               - 'legacy/demo/**'
               - 'legacy/Makefile'
               - '.github/workflows/legacy-build.yml'
+            v3.3:
+              - *shared
+              - 'legacy/3.3/**'
             v4.0:
               - *shared
               - 'legacy/4.0/**'
@@ -55,7 +58,7 @@ jobs:
           BUILD_ALL: ${{ github.event_name != 'pull_request' }}
         run: |
           # Implemented versions; append when a new directory lands.
-          ALL='["4.0","4.1","4.2"]'
+          ALL='["3.3","4.0","4.1","4.2"]'
           if [ "${BUILD_ALL}" = "true" ]; then
             VERSIONS="${ALL}"
           else

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
 # Changelog
+- Add Plone 3.3 image to the legacy matrix. Refs #184
+  [@ericof]
 - Add Plone 4.0 image to the legacy matrix. Refs #183
   [@ericof]
 - Add Plone 4.1 image to the legacy matrix. Refs #182

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ listed; earlier point releases remain in the repository and on Docker Hub.
 | 4.2.6 | 2.7.18 | Debian *(legacy)* | [`legacy/4.2/Dockerfile`](legacy/4.2/Dockerfile) | `4.2`, `4.2.6`, `4.2-demo`, `4.2.6-demo` |
 | 4.1.6 | 2.6.9 | Debian *(legacy)* | [`legacy/4.1/Dockerfile`](legacy/4.1/Dockerfile) | `4.1`, `4.1.6`, `4.1-demo`, `4.1.6-demo` |
 | 4.0.9 | 2.6.9 | Debian *(legacy)* | [`legacy/4.0/Dockerfile`](legacy/4.0/Dockerfile) | `4.0`, `4.0.9`, `4.0-demo`, `4.0.9-demo` |
+| 3.3.6 | 2.4.6 | Debian *(legacy)* | [`legacy/3.3/Dockerfile`](legacy/3.3/Dockerfile) | `3.3`, `3.3.6`, `3.3-demo`, `3.3.6-demo` |
 
 ### Where the tags live
 

--- a/legacy/3.3/Dockerfile
+++ b/legacy/3.3/Dockerfile
@@ -1,0 +1,133 @@
+# syntax=docker/dockerfile:1
+#
+# Plone 3.3.x — buildout era (Zope 2.10.13 / Python 2.4.x)
+#
+# Strategy:
+#   Stage 1 (fetch): modern userland downloads everything (old TLS never touches network)
+#   Stage 2 (build): Python 2.4 + PIL, then an OFFLINE buildout from the
+#                    UnifiedInstaller's bundled buildout-cache
+#   Stage 3 (runtime): slim image, non-root, /data volume, port 8080
+#
+# [V 2026-08-20] The installer bundles Python 2.4.6, NOT the 2.6.9 the version
+# matrix predicted, so this image keeps the same interpreter as 3.0/3.1 and the
+# shared build-python2.sh applies unchanged.
+#
+# NOT FOR PRODUCTION. Zope 2.10.13 has known, unpatched security issues.
+# Intended for content extraction, migration, and archaeology only.
+
+ARG PYTHON_VERSION=2.4.6
+ARG PLONE_VERSION=3.3.6
+ARG PIL_VERSION=1.1.6
+# Zope is NOT fetched separately: the installer's buildout-cache ships the Zope
+# tarball and plone.recipe.zope2install builds it during buildout.
+ARG ZOPE_VERSION=2.10.13
+
+ARG PYTHON_URL=https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz
+# [V 2026-08-20] Verified downloadable from Launchpad. dist.plone.org has no
+# equivalent complete bundle for this series.
+ARG PLONE_URL=https://launchpad.net/plone/3.3/${PLONE_VERSION}/+download/Plone-${PLONE_VERSION}-UnifiedInstaller.tgz
+ARG PIL_URL=https://dist.plone.org/thirdparty/PIL-${PIL_VERSION}.tar.gz
+
+# --- simplejson -------------------------------------------------------------
+# 3.3 is the ONE pre-4.0 series that needs no simplejson install, and is
+# deliberately left alone. [V 2026-08-27] Its UnifiedInstaller's buildout-cache
+# already ships simplejson-2.0.9-py2.4.egg AND puts it on the instance's
+# sys.path — `bin/instance run` imports it on the built image, verified rather
+# than assumed. Installing a second copy into site-packages would shadow the
+# egg with no benefit and one more thing to disagree with itself.
+#
+# Every other pre-4.0 series carries ARG SIMPLEJSON_VERSION and the fetch-
+# simplejson stage; 4.0+ (Python 2.6/2.7) get `json` from the stdlib.
+
+# ---------------------------------------------------------------------------
+# Stage 1: fetch — modern TLS, nothing else
+# ---------------------------------------------------------------------------
+FROM debian:bookworm-slim AS fetch
+ARG PYTHON_URL
+ARG PLONE_URL
+ARG PIL_URL
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates curl \
+ && rm -rf /var/lib/apt/lists/*
+WORKDIR /dist
+# --retry: Launchpad intermittently answers 503 under load (observed
+# 2026-08-20), and a transient failure here wastes the whole build.
+RUN curl -fSL --retry 5 --retry-delay 5 "${PYTHON_URL}" -o python.tgz \
+ && curl -fSL --retry 5 --retry-delay 5 "${PLONE_URL}"  -o installer.tgz \
+ && curl -fSL --retry 5 --retry-delay 5 "${PIL_URL}"    -o pil.tar.gz
+
+# ---------------------------------------------------------------------------
+# Stage 2a: pybuild — Python 2.4 only (gate G1)
+# ---------------------------------------------------------------------------
+FROM debian:bookworm AS pybuild
+ARG PYTHON_VERSION
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      gcc make libc6-dev zlib1g-dev libcrypt-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=fetch /dist /dist
+COPY shared/build-python2.sh /usr/local/bin/build-python2.sh
+
+RUN build-python2.sh /dist/python.tgz "${PYTHON_VERSION}" /opt/python2.4
+
+# ---------------------------------------------------------------------------
+# Stage 2b: build — PIL, then the offline buildout.
+# ---------------------------------------------------------------------------
+FROM pybuild AS build
+ARG PLONE_VERSION
+ARG PIL_VERSION
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends libjpeg62-turbo-dev bzip2 \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY shared/build-pil.sh /usr/local/bin/build-pil.sh
+RUN build-pil.sh /dist/pil.tar.gz "${PIL_VERSION}" /opt/python2.4/bin/python2.4
+
+COPY shared/build-plone-buildout.sh /usr/local/bin/build-plone-buildout.sh
+RUN build-plone-buildout.sh /dist/installer.tgz "${PLONE_VERSION}" \
+      /opt/python2.4/bin/python2.4 /app
+
+# ---------------------------------------------------------------------------
+# Stage 3: runtime
+# ---------------------------------------------------------------------------
+FROM debian:bookworm-slim
+ARG PLONE_VERSION
+ARG ZOPE_VERSION
+ARG PYTHON_VERSION
+
+LABEL org.opencontainers.image.title="Plone ${PLONE_VERSION} (legacy)" \
+      org.opencontainers.image.description="Plone ${PLONE_VERSION} on Zope ${ZOPE_VERSION} / Python ${PYTHON_VERSION}. Migration and content-extraction use only — NOT for production." \
+      org.opencontainers.image.vendor="Simples Consultoria"
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends zlib1g libcrypt1 libjpeg62-turbo \
+ && rm -rf /var/lib/apt/lists/* \
+ && useradd --system -m -d /app -U -u 500 plone \
+ && mkdir -p /data \
+ && chown -R plone:plone /data
+
+COPY --from=build --chown=plone:plone /opt/python2.4 /opt/python2.4
+COPY --from=build --chown=plone:plone /app /app
+COPY --chown=plone:plone shared/docker-entrypoint-buildout.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+COPY --chown=plone:plone shared/upgrade-plone.py /app/upgrade-plone.py
+COPY --chown=plone:plone shared/configure-zeo.sh /app/configure-zeo.sh
+RUN chmod +x /app/configure-zeo.sh
+
+ENV INSTANCE_HOME=/app/instance \
+    PYTHON=/opt/python2.4/bin/python2.4 \
+    ZOPE_HTTP_PORT=8080
+
+VOLUME /data
+EXPOSE 8080
+WORKDIR /app/instance
+USER plone
+
+HEALTHCHECK --interval=10s --timeout=5s --start-period=180s --retries=6 \
+  CMD ["/opt/python2.4/bin/python2.4", "-c", "import urllib; urllib.urlopen('http://127.0.0.1:8080/')"]
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["start"]

--- a/legacy/3.3/README.md
+++ b/legacy/3.3/README.md
@@ -1,0 +1,64 @@
+# Plone 3.3 legacy image
+
+Plone 3.3.6 on Zope 2.10.13 / Python 2.4.6. Buildout era.
+
+**Not for production.** Zope 2.10.13 has known, unpatched vulnerabilities. This
+image exists for content extraction, migration rehearsal, and historical
+inspection.
+
+## Usage
+
+```sh
+docker build -f 3.3/Dockerfile -t plone-legacy:3.3.6 .
+docker run -d -p 8080:8080 -e ADMIN_PASSWORD=secret \
+    -v plone33-data:/data plone-legacy:3.3.6
+```
+
+| | |
+|---|---|
+| Port | 8080 (`ZOPE_HTTP_PORT` to change) |
+| Volume | `/data` (`filestorage/Data.fs`, `log/`) |
+| User | `plone` (uid 500) |
+| Env | `ADMIN_USER`, `ADMIN_PASSWORD` (first run only) |
+| PIL | 1.1.6, with JPEG + PNG |
+
+## How it is built
+
+Like 3.1, from the Launchpad **UnifiedInstaller**, whose
+`packages/buildout-cache.tar.bz2` is a complete offline cache — every egg and
+product tarball plus Zope itself. `bin/buildout -No` runs fully offline, so the
+2000s-era toolchain never has to negotiate modern TLS. See
+`shared/build-plone-buildout.sh`.
+
+## Validated facts / hypotheses
+
+- **[V 2026-08-20]** **Python 2.4.6, not 2.6.9.** The matrix predicted 2.6.9 for
+  3.3, but the 3.3.6 UnifiedInstaller bundles `Python-2.4.6.tar.bz2` — so this
+  image keeps the same interpreter as 3.0/3.1/3.2 and the shared
+  `build-python2.sh` applies unchanged. Plone 3.3 *supports* 2.6, but 2.4.6 is
+  what the vendor shipped and therefore what the cached eggs were built for
+  (they are all `-py2.4.egg`).
+- **[V 2026-08-20]** **The self-correcting bootstrap earned its keep.** Every
+  installer's `bin/buildout` hardcodes `setuptools-0.6c8-py2.4.egg` and
+  `zc.buildout-1.1.1-py2.4.egg`, but the caches actually ship:
+
+  | Version | setuptools | zc.buildout |
+  |---|---|---|
+  | 3.1.7 | 0.6c9 | 1.1.1 |
+  | 3.2.3 | 0.6c9 | 1.1.2 |
+  | 3.3.6 | 0.6c11 | 1.4.4 |
+
+  Regenerating that script from what is actually in the cache — rather than
+  patching the vendor's stale paths — is what let one shared script cover all
+  three without per-version special cases.
+- **[V 2026-08-20]** Zope is 2.10.13 (`/app/Zope-2.10.13-final-py2.4`), matching
+  the matrix for once.
+- **[V 2026-08-20]** Zero product import/install errors; a Plone 3.3 site is
+  created and renders ~21 kB with the Plone `generator` meta tag. Passes twice.
+
+## Smoke test (CI gate)
+
+```sh
+make test-3.3
+SMOKE_CREATE_SITE=1 make test-3.3
+```

--- a/legacy/Makefile
+++ b/legacy/Makefile
@@ -14,7 +14,7 @@ PLATFORM ?= linux/amd64
 # the matrix in README.md, and the ALL list in
 # ../.github/workflows/legacy-build.yml. One series lands per pull request;
 # append here as each one is ported.
-SERIES := 4.0 4.1 4.2
+SERIES := 3.3 4.0 4.1 4.2
 
 # Builder used for the -demo images, which MUST be a `docker`-driver one:
 # demo/Dockerfile's FROM reads the base image out of the local image store, and
@@ -42,6 +42,7 @@ DEMO_TEST_PASSWORD ?= smoke-not-admin
 # these images are built from.
 # [V 2026-08-20] 4.1.6 is both the final 4.1.x release and the last
 # UnifiedInstaller published for the series, so this row needs no compromise.
+FULL_VERSION_3.3 := 3.3.6
 # [V 2026-08-20] 4.0.9, not 4.0.10: 4.0.10 is the final release and its egg
 # set exists at dist.plone.org/release/4.0.10/, but Launchpad published no
 # UnifiedInstaller past 4.0.9 — and the installer is what carries the offline

--- a/legacy/README.md
+++ b/legacy/README.md
@@ -15,9 +15,10 @@ They exist for content extraction, migration rehearsal, and archaeology.
 | 4.2  | 4.2.6 | 2.13.21 | 2.7.18 | buildout | stdlib `json` | **done** |
 | 4.1  | 4.1.6 | 2.13.15 | 2.6.9  | buildout | stdlib `json` | **done** |
 | 4.0  | 4.0.9 | 2.12.19 | 2.6.9  | buildout | stdlib `json` | **done** |
+| 3.3  | 3.3.6 | 2.10.13 | 2.4.6  | buildout | `simplejson` 2.0.9 (bundled) | **done** |
 
 The matrix extends down to Plone 1.0. One series lands per pull request; the
-remaining eight follow these. When adding a series, keep four places in sync:
+remaining seven follow these. When adding a series, keep four places in sync:
 the directory, the table above, `SERIES` and `FULL_VERSION_*` in the
 [`Makefile`](Makefile), and the paths-filter list plus `ALL` in
 [`../.github/workflows/legacy-build.yml`](../.github/workflows/legacy-build.yml).


### PR DESCRIPTION
Adds the **Plone 3.3** image — the fourth series of the legacy matrix, and the first below 4.x. #180 established the `legacy/` subtree, the shared scripts and `legacy-build.yml`; #182, #183 added 4.1 and 4.0.

These images are for **content extraction, migration rehearsal and archaeology only**. The stacks have known, unpatched security issues and must never be exposed.

Closes #184

## No new shared scripts — 3.3 is on the buildout side of the seam

The matrix's central seam is not 3.x/4.x, it is **tarball era vs buildout era**, and 3.3 sits on the same side as 4.x. Tracing the closure at the call sites (anchored on `shared/`, so the `COPY` *destination* `/docker-entrypoint.sh` doesn't produce a false match on every file):

| Entrypoint | Series |
|---|---|
| `shared/docker-entrypoint.sh` (tarball) | 1.0, 2.0, 2.1, 2.5, 3.0 |
| `shared/docker-entrypoint-buildout.sh` | **3.1, 3.2, 3.3**, 4.0, 4.1, 4.2 |

So 3.3 `COPY`s the same six scripts as 4.0, all already present and byte-identical to their counterparts in the source repository. The three unported scripts stay unported, and belong to the series that actually reference them: `docker-entrypoint.sh` (1.0–3.0), `build-elementtree.sh` (3.0 only) and `install-simplejson.sh` (1.0–3.2).

## What differs from 4.0

| | 4.0 | 3.3 |
|---|---|---|
| Plone | 4.0.9 | **3.3.6** |
| Zope | 2.12.19, an **egg** | **2.10.13, a tarball** built by `plone.recipe.zope2install` |
| Python | 2.6.9 | **2.4.6** |
| JSON | stdlib `json` | **`simplejson` 2.0.9, bundled** |
| Build/runtime deps | identical | identical |

### Python 2.4.6, not the 2.6.9 the matrix predicted

The 3.3.6 UnifiedInstaller bundles `Python-2.4.6.tar.bz2` and every cached egg is `-py2.4`, so the interpreter is not a free choice. Plone 3.3 *supports* 2.6, but 2.4.6 is what the vendor shipped and therefore what the eggs were built against.

This is also the interpreter that needs `build-python2.sh`'s **full** mitigation set — the `BASECFLAGS` override, `--without-cxx`, and the multiarch patch. The 2.6/2.7 path skips all three (2.6 rejects `--without-cxx` outright; 2.7 needs no multiarch patch). The script probes for each condition rather than branching on version, which is exactly why it covers 2.4 through 2.7 unchanged.

### The one pre-4.0 series that installs nothing for JSON

3.3's buildout-cache already ships `simplejson-2.0.9-py2.4.egg` **and** puts it on the instance's `sys.path`. Installing a second copy into `site-packages` would shadow the egg for no benefit. The smoke gate confirms the round-trip at run time rather than assuming it.

Source: `https://launchpad.net/plone/3.3/3.3.6/+download/Plone-3.3.6-UnifiedInstaller.tgz`

## Verification

| Check | Result |
|---|---|
| `make lint` — hadolint ×5, shellcheck ×8, yq | pass |
| Base smoke test (`SMOKE_CREATE_SITE=1`) | pass, 6/6 gates |
| `-demo` build + `make test-demo-3.3` | pass, 6/6 gates |
| `make -n` on all four targets, GNU Make 3.81 | correct, incl. the stem trap |

Six gates rather than 4.x's seven — the theme-profile assertion is 4.x-only. The gate shows both era-specific paths working: JSON round-trips **via `simplejson` 2.0.9**, and site creation discovers `addPloneSiteForm -> addPloneSite` rather than 4.x's `zmi_constructor -> @@plone-addsite`.

Version claims were read out of the built image rather than assumed:

```
Plone-3.3.6-py2.4.egg
/app/Zope-2.10.13-final-py2.4
Python 2.4.6
simplejson-2.0.9-py2.4.egg
```

**Cold-build status:** the base image's local build was cache hits off the source repository, so its cold build happens for the first time in CI — same as every series so far. The `-demo` layer *was* built for real here, so the 3.x site-creation path is exercised end to end locally.

## Published tags

The root README's 3.3 row names its four tags rather than saying *not yet published*, following #183. The `description` job runs `needs: build` on pushes to `main`, so the sequence at merge is *push the tags, then sync README.md to the Docker Hub page* — a row reading *not yet published* would be false at the moment Hub receives it.

That reasoning has since been confirmed end to end: the post-merge run for #199 went green including `description`, and `4.0`, `4.0.9`, `4.0-demo`, `4.0.9-demo` are now live on both `plone/plone` and `ghcr.io/plone/plone.docker`.

## Follow-ups

- Seven series remain, one PR each: #185 (3.2), #186 (3.1), #187 (3.0), #194 (2.5), #195 (2.1), #196 (2.0), #197 (1.0). #185 and #186 should be cheap — both are buildout era. **#187 (3.0) is the seam**: first tarball-era entrypoint, and it needs both `build-elementtree.sh` and `install-simplejson.sh` ported.
- `legacy/README.md` still shows only the local `plone-legacy:4.2` tags in its quick start, not the published `plone/plone:4.2`. Carried over from #182.
- `legacy/README.md`'s prose is still written around 4.2 alone — the "JSON" section explains only Python 2.7's stdlib `json`, which is now actively misleading with a `simplejson` series in the matrix, and the era paragraph names only 4.2. Carried over from #183, and worth doing before 3.2 lands.
