### PR TITLE
Add the Plone 3.2 legacy image

### DIFF
--- a/.github/workflows/legacy-build.yml
+++ b/.github/workflows/legacy-build.yml
@@ -37,6 +37,9 @@ jobs:
               - 'legacy/demo/**'
               - 'legacy/Makefile'
               - '.github/workflows/legacy-build.yml'
+            v3.2:
+              - *shared
+              - 'legacy/3.2/**'
             v3.3:
               - *shared
               - 'legacy/3.3/**'
@@ -58,7 +61,7 @@ jobs:
           BUILD_ALL: ${{ github.event_name != 'pull_request' }}
         run: |
           # Implemented versions; append when a new directory lands.
-          ALL='["3.3","4.0","4.1","4.2"]'
+          ALL='["3.2","3.3","4.0","4.1","4.2"]'
           if [ "${BUILD_ALL}" = "true" ]; then
             VERSIONS="${ALL}"
           else

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
 # Changelog
+- Add Plone 3.2 image to the legacy matrix. Refs #185
+  [@ericof]
 - Add Plone 3.3 image to the legacy matrix. Refs #184
   [@ericof]
 - Add Plone 4.0 image to the legacy matrix. Refs #183

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ listed; earlier point releases remain in the repository and on Docker Hub.
 | 4.1.6 | 2.6.9 | Debian *(legacy)* | [`legacy/4.1/Dockerfile`](legacy/4.1/Dockerfile) | `4.1`, `4.1.6`, `4.1-demo`, `4.1.6-demo` |
 | 4.0.9 | 2.6.9 | Debian *(legacy)* | [`legacy/4.0/Dockerfile`](legacy/4.0/Dockerfile) | `4.0`, `4.0.9`, `4.0-demo`, `4.0.9-demo` |
 | 3.3.6 | 2.4.6 | Debian *(legacy)* | [`legacy/3.3/Dockerfile`](legacy/3.3/Dockerfile) | `3.3`, `3.3.6`, `3.3-demo`, `3.3.6-demo` |
+| 3.2.3 | 2.4.6 | Debian *(legacy)* | [`legacy/3.2/Dockerfile`](legacy/3.2/Dockerfile) | `3.2`, `3.2.3`, `3.2-demo`, `3.2.3-demo` |
 
 ### Where the tags live
 

--- a/legacy/3.2/Dockerfile
+++ b/legacy/3.2/Dockerfile
@@ -1,0 +1,156 @@
+# syntax=docker/dockerfile:1
+#
+# Plone 3.2.x — buildout era (Zope 2.10.7 / Python 2.4.x)
+#
+# Strategy:
+#   Stage 1 (fetch): modern userland downloads everything (old TLS never touches network)
+#   Stage 2 (build): Python 2.4 + PIL, then an OFFLINE buildout from the
+#                    UnifiedInstaller's bundled buildout-cache
+#   Stage 3 (runtime): slim image, non-root, /data volume, port 8080
+#
+# [V 2026-08-20] Buildout era. The installer uses the base_skeleton +
+# buildout_templates layout introduced after 3.1 (the same shape the official
+# plone/plone.docker images consume for 4.3), handled by the shared script.
+#
+# NOT FOR PRODUCTION. Zope 2.10.7 has known, unpatched security issues.
+# Intended for content extraction, migration, and archaeology only.
+
+ARG PYTHON_VERSION=2.4.6
+ARG PLONE_VERSION=3.2.3
+ARG PIL_VERSION=1.1.6
+# Zope is NOT fetched separately: the installer's buildout-cache ships the Zope
+# tarball and plone.recipe.zope2install builds it during buildout.
+# [V 2026-08-20] The 3.2.3 installer's buildout-cache ships Zope 2.10.7
+# (verified from the built image: /app/Zope-2.10.7-final-py2.4).
+ARG ZOPE_VERSION=2.10.7
+
+ARG PYTHON_URL=https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz
+# [V 2026-08-20] Verified downloadable from Launchpad. dist.plone.org has no
+# equivalent complete bundle for this series.
+ARG PLONE_URL=https://launchpad.net/plone/3.2/${PLONE_VERSION}/+download/Plone-${PLONE_VERSION}-UnifiedInstaller.tgz
+ARG PIL_URL=https://dist.plone.org/thirdparty/PIL-${PIL_VERSION}.tar.gz
+
+# --- simplejson -------------------------------------------------------------
+# Python has no stdlib `json` before 2.6, so every image below 4.0 ships
+# simplejson instead. The release is NOT interchangeable between interpreters
+# — see the header of shared/install-simplejson.sh, and note that the install
+# gate will fail the build on a wrong pairing rather than let it through.
+ARG SIMPLEJSON_VERSION=2.0.9
+ARG SIMPLEJSON_URL=https://files.pythonhosted.org/packages/source/s/simplejson/simplejson-${SIMPLEJSON_VERSION}.tar.gz
+
+# ---------------------------------------------------------------------------
+# Stage 1: fetch — modern TLS, nothing else
+# ---------------------------------------------------------------------------
+FROM debian:bookworm-slim AS fetch
+ARG PYTHON_URL
+ARG PLONE_URL
+ARG PIL_URL
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates curl \
+ && rm -rf /var/lib/apt/lists/*
+WORKDIR /dist
+# --retry: Launchpad intermittently answers 503 under load (observed
+# 2026-08-20), and a transient failure here wastes the whole build.
+RUN curl -fSL --retry 5 --retry-delay 5 "${PYTHON_URL}" -o python.tgz \
+ && curl -fSL --retry 5 --retry-delay 5 "${PLONE_URL}"  -o installer.tgz \
+ && curl -fSL --retry 5 --retry-delay 5 "${PIL_URL}"    -o pil.tar.gz
+
+# ---------------------------------------------------------------------------
+# Stage 1b: fetch-simplejson — derived from fetch, deliberately not part of it
+# ---------------------------------------------------------------------------
+# pybuild does `COPY --from=fetch /dist /dist`, so folding this download into
+# stage 1 would invalidate the interpreter build every time the simplejson pin
+# moves and recompile CPython from source — hours, under emulation on an arm64
+# host. Deriving a stage leaves `fetch` byte-identical, so pybuild stays cached,
+# and reuses the curl and ca-certificates already installed there. WORKDIR
+# /dist is inherited, so the tarball lands beside the others.
+FROM fetch AS fetch-simplejson
+ARG SIMPLEJSON_URL
+RUN curl -fSL --retry 5 --retry-delay 5 "${SIMPLEJSON_URL}" -o simplejson.tar.gz
+
+# ---------------------------------------------------------------------------
+# Stage 2a: pybuild — Python 2.4 only (gate G1)
+# ---------------------------------------------------------------------------
+FROM debian:bookworm AS pybuild
+ARG PYTHON_VERSION
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      gcc make libc6-dev zlib1g-dev libcrypt-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=fetch /dist /dist
+COPY shared/build-python2.sh /usr/local/bin/build-python2.sh
+
+RUN build-python2.sh /dist/python.tgz "${PYTHON_VERSION}" /opt/python2.4
+
+# ---------------------------------------------------------------------------
+# Stage 2b: build — PIL, then the offline buildout.
+# ---------------------------------------------------------------------------
+FROM pybuild AS build
+ARG PLONE_VERSION
+ARG PIL_VERSION
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends libjpeg62-turbo-dev bzip2 \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY shared/build-pil.sh /usr/local/bin/build-pil.sh
+RUN build-pil.sh /dist/pil.tar.gz "${PIL_VERSION}" /opt/python2.4/bin/python2.4
+
+COPY shared/build-plone-buildout.sh /usr/local/bin/build-plone-buildout.sh
+RUN build-plone-buildout.sh /dist/installer.tgz "${PLONE_VERSION}" \
+      /opt/python2.4/bin/python2.4 /app
+
+# --- simplejson -------------------------------------------------------------
+# Last in the stage, and with its ARG declared here rather than at the top, so
+# that moving the pin does not invalidate the PIL and Plone layers above.
+# site-packages lives under /opt/python2.4, which stage 3 copies wholesale, so
+# nothing further is needed at runtime.
+ARG SIMPLEJSON_VERSION
+COPY --from=fetch-simplejson /dist/simplejson.tar.gz /dist/simplejson.tar.gz
+COPY shared/install-simplejson.sh /usr/local/bin/install-simplejson.sh
+RUN install-simplejson.sh /dist/simplejson.tar.gz "${SIMPLEJSON_VERSION}" \
+      /opt/python2.4/bin/python2.4
+
+# ---------------------------------------------------------------------------
+# Stage 3: runtime
+# ---------------------------------------------------------------------------
+FROM debian:bookworm-slim
+ARG PLONE_VERSION
+ARG ZOPE_VERSION
+ARG PYTHON_VERSION
+
+LABEL org.opencontainers.image.title="Plone ${PLONE_VERSION} (legacy)" \
+      org.opencontainers.image.description="Plone ${PLONE_VERSION} on Zope ${ZOPE_VERSION} / Python ${PYTHON_VERSION}. Migration and content-extraction use only — NOT for production." \
+      org.opencontainers.image.vendor="Simples Consultoria"
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends zlib1g libcrypt1 libjpeg62-turbo \
+ && rm -rf /var/lib/apt/lists/* \
+ && useradd --system -m -d /app -U -u 500 plone \
+ && mkdir -p /data \
+ && chown -R plone:plone /data
+
+COPY --from=build --chown=plone:plone /opt/python2.4 /opt/python2.4
+COPY --from=build --chown=plone:plone /app /app
+COPY --chown=plone:plone shared/docker-entrypoint-buildout.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+COPY --chown=plone:plone shared/upgrade-plone.py /app/upgrade-plone.py
+COPY --chown=plone:plone shared/configure-zeo.sh /app/configure-zeo.sh
+RUN chmod +x /app/configure-zeo.sh
+
+ENV INSTANCE_HOME=/app/instance \
+    PYTHON=/opt/python2.4/bin/python2.4 \
+    ZOPE_HTTP_PORT=8080
+
+VOLUME /data
+EXPOSE 8080
+WORKDIR /app/instance
+USER plone
+
+HEALTHCHECK --interval=10s --timeout=5s --start-period=180s --retries=6 \
+  CMD ["/opt/python2.4/bin/python2.4", "-c", "import urllib; urllib.urlopen('http://127.0.0.1:8080/')"]
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["start"]

--- a/legacy/3.2/README.md
+++ b/legacy/3.2/README.md
@@ -1,0 +1,66 @@
+# Plone 3.2 legacy image
+
+Plone 3.2.3 on Zope 2.10.7 / Python 2.4.6. Buildout era.
+
+**Not for production.** Zope 2.10.7 has known, unpatched vulnerabilities. This
+image exists for content extraction, migration rehearsal, and historical
+inspection.
+
+## Usage
+
+```sh
+docker build -f 3.2/Dockerfile -t plone-legacy:3.2.3 .
+docker run -d -p 8080:8080 -e ADMIN_PASSWORD=secret \
+    -v plone32-data:/data plone-legacy:3.2.3
+```
+
+| | |
+|---|---|
+| Port | 8080 (`ZOPE_HTTP_PORT` to change) |
+| Volume | `/data` (`filestorage/Data.fs`, `log/`) |
+| User | `plone` (uid 500) |
+| Env | `ADMIN_USER`, `ADMIN_PASSWORD` (first run only) |
+| PIL | 1.1.6, with JPEG + PNG |
+
+## How it is built
+
+Like 3.1, from the Launchpad **UnifiedInstaller**, whose
+`packages/buildout-cache.tar.bz2` is a complete offline cache — every egg and
+product tarball plus Zope itself. `bin/buildout -No` runs fully offline, so the
+2000s-era toolchain never has to negotiate modern TLS. See
+`shared/build-plone-buildout.sh`.
+
+## Validated facts / hypotheses
+
+- **[V 2026-08-20]** **The installer layout changed after 3.1.** 3.1 ships a
+  complete `standalone_template/`; 3.2 ships `base_skeleton/` (no buildout.cfg)
+  plus `buildout_templates/standalone.cfg` to drop in. This is the same shape
+  the official `plone/plone.docker` images consume for 4.3, so it is the one
+  that persists. `shared/build-plone-buildout.sh` detects which it has and
+  fails loudly on anything else.
+- **[V 2026-08-20]** **Zope here is 2.10.7, not 2.10.8.** The version was
+  corrected from a guess after reading it off the built image
+  (`/app/Zope-2.10.7-final-py2.4`). The installer's cache decides this, not the
+  matrix.
+- **[V 2026-08-20]** **There is no `parts/plone` from 3.2 on.** Plone arrives as
+  eggs, so 3.1's post-buildout assertion (copied from the vendor's own
+  `standalone-mode.sh`) had to be replaced with checks on `bin/instance` and the
+  generated `parts/instance/etc/zope.conf`, which are universal.
+- **[V 2026-08-20]** **Zope moves out of the instance.** 3.2's template sets
+  `zope-directory`, so Zope installs to `/app/Zope-<ver>-py2.4/` rather than
+  `<instance>/parts/zope2/`. The entrypoint therefore *discovers*
+  `utilities/zpasswd.py` instead of hardcoding 3.1's path — that hardcoded path
+  was what made the first 3.2 container exit 1 with no log at all.
+- **[V 2026-08-20]** Non-root handling follows the installer's own
+  `helper_scripts/create_instance.py`: delete the `effective-user` options and
+  strip the `chown` commands. A leftover `__PLACEHOLDER__` on a live line is now
+  a build failure.
+- **[V 2026-08-20]** Zero product import/install errors; a Plone 3.2 site is
+  created and renders ~21 kB with the Plone `generator` meta tag. Passes twice.
+
+## Smoke test (CI gate)
+
+```sh
+make test-3.2
+SMOKE_CREATE_SITE=1 make test-3.2
+```

--- a/legacy/Makefile
+++ b/legacy/Makefile
@@ -14,7 +14,7 @@ PLATFORM ?= linux/amd64
 # the matrix in README.md, and the ALL list in
 # ../.github/workflows/legacy-build.yml. One series lands per pull request;
 # append here as each one is ported.
-SERIES := 3.3 4.0 4.1 4.2
+SERIES := 3.2 3.3 4.0 4.1 4.2
 
 # Builder used for the -demo images, which MUST be a `docker`-driver one:
 # demo/Dockerfile's FROM reads the base image out of the local image store, and
@@ -42,6 +42,7 @@ DEMO_TEST_PASSWORD ?= smoke-not-admin
 # these images are built from.
 # [V 2026-08-20] 4.1.6 is both the final 4.1.x release and the last
 # UnifiedInstaller published for the series, so this row needs no compromise.
+FULL_VERSION_3.2 := 3.2.3
 FULL_VERSION_3.3 := 3.3.6
 # [V 2026-08-20] 4.0.9, not 4.0.10: 4.0.10 is the final release and its egg
 # set exists at dist.plone.org/release/4.0.10/, but Launchpad published no

--- a/legacy/README.md
+++ b/legacy/README.md
@@ -16,9 +16,10 @@ They exist for content extraction, migration rehearsal, and archaeology.
 | 4.1  | 4.1.6 | 2.13.15 | 2.6.9  | buildout | stdlib `json` | **done** |
 | 4.0  | 4.0.9 | 2.12.19 | 2.6.9  | buildout | stdlib `json` | **done** |
 | 3.3  | 3.3.6 | 2.10.13 | 2.4.6  | buildout | `simplejson` 2.0.9 (bundled) | **done** |
+| 3.2  | 3.2.3 | 2.10.7  | 2.4.6  | buildout | `simplejson` 2.0.9 (installed) | **done** |
 
 The matrix extends down to Plone 1.0. One series lands per pull request; the
-remaining seven follow these. When adding a series, keep four places in sync:
+remaining six follow these. When adding a series, keep four places in sync:
 the directory, the table above, `SERIES` and `FULL_VERSION_*` in the
 [`Makefile`](Makefile), and the paths-filter list plus `ALL` in
 [`../.github/workflows/legacy-build.yml`](../.github/workflows/legacy-build.yml).
@@ -93,9 +94,11 @@ are applied to the seeded database before Zope starts serving, since Zope's own
 
 ## JSON
 
-Python 2.7 has a stdlib `json`, so 4.2 needs nothing extra. Earlier series ship
-`simplejson` instead; import defensively if one script must cover the whole
-matrix:
+Python grew a stdlib `json` in 2.6, so the 4.x series need nothing extra. Every
+series below 4.0 ships `simplejson` 2.0.9 instead — 3.3 finds it already in its
+own buildout-cache, while 3.2 and earlier have it installed by
+`shared/install-simplejson.sh`. Import defensively if one script must cover the
+whole matrix:
 
 ```python
 try:
@@ -212,12 +215,13 @@ Shared build logic lives in `shared/`:
 | `reset-admin-password.py` | Applies `ADMIN_USER`/`ADMIN_PASSWORD` to a seeded database |
 | `configure-zeo.sh` | Rewrites `zope.conf` into a ZEO client when `ZEO_ADDRESS` is set |
 | `upgrade-plone.py` | Runs `portal_migration` and commits it, behind the `upgrade` command |
+| `install-simplejson.sh` | Installs simplejson into a pre-2.6 interpreter, with a `sort_keys` round-trip gate |
 | `json-probe.py` | Asserts a JSON module imports and round-trips, used by the smoke test |
 | `smoke-test.sh` | The CI gate: HTTP, auth, product load, optional site creation |
 
-Three further scripts arrive with the earlier series they serve:
-`build-elementtree.sh` (Plone 3), `install-simplejson.sh` (pre-4.0) and
-`docker-entrypoint.sh` (tarball era, 1.0 – 3.0).
+Two further scripts arrive with the earlier series they serve:
+`build-elementtree.sh` (Plone 3.0) and `docker-entrypoint.sh` (tarball era,
+1.0 – 3.0).
 
 Per-version notes — including each version's validated/hypothesised ledger —
 live in that version directory's README.

--- a/legacy/shared/install-simplejson.sh
+++ b/legacy/shared/install-simplejson.sh
@@ -1,0 +1,104 @@
+#!/bin/sh
+# Install simplejson (pure Python) into a historical CPython 2.x.
+#
+# Usage: install-simplejson.sh <sdist-tarball> <version> <python-binary>
+#   e.g. install-simplejson.sh /dist/simplejson.tar.gz 2.0.9 \
+#            /opt/python2.4/bin/python2.4
+#
+# WHY: Python grew a stdlib `json` only in 2.6. Every image below 4.0 runs
+# Python 2.3 or 2.4 and therefore has no JSON support at all — which makes
+# scripted content extraction, the entire purpose of these images, needlessly
+# painful. 4.0/4.1 (2.6.9) and 4.2 (2.7.18) need nothing.
+#
+# [V 2026-08-27] Plone 3.3 is deliberately NOT patched: its UnifiedInstaller
+# already ships simplejson-2.0.9-py2.4.egg in the buildout-cache AND puts it on
+# the instance's sys.path — `bin/instance run` imports it today, verified on the
+# built image.
+#
+# The C `_speedups` extension is deliberately NOT built. simplejson ships a
+# complete pure-Python fallback; these images are for archaeology rather than
+# throughput; and skipping it keeps the install a plain directory copy with no
+# compiler in the loop, identical in the tarball-era and buildout-era images.
+#
+# [V 2026-08-27] A plain drop-in into site-packages is enough — no buildout
+# part, no egg, no .pth. site-packages IS on sys.path for BOTH script runners:
+# `zopectl run` (tarball era) and `bin/instance run` (buildout era). Verified by
+# mounting the package in and importing it through the entrypoint on 2.5 and
+# 3.2; both answered with a working dumps().
+#
+# VERSION PER INTERPRETER. Chosen by running simplejson's OWN unit suite inside
+# these images [V 2026-08-27]:
+#
+#   Python 2.3  ->  1.9.3   24 tests, 0 failures, 0 errors.
+#   Python 2.4  ->  2.0.9   33 tests, 0 failures, 0 errors. Also the exact
+#                           version Plone 3.3's own installer shipped.
+#
+# 2.0.9 does NOT work on Python 2.3: encoder.py does `items.sort(key=...)`, and
+# the key= argument is 2.4+, so dumps(sort_keys=True) raises TypeError while
+# every other call still works. That is precisely the kind of failure that
+# surfaces months later inside somebody's export script, so the gate below
+# exercises sort_keys deliberately: pairing the wrong release with an
+# interpreter is a BUILD failure here, not a surprise there.
+#
+# (Two of simplejson's test modules skip on 2.3 because they import `decimal`,
+# which is itself 2.4+. That is the interpreter, not simplejson.)
+set -eu
+
+SRC="${1:?usage: install-simplejson.sh <sdist-tarball> <version> <python>}"
+VERSION="${2:?missing version}"
+PYTHON="${3:?missing python binary}"
+
+BUILD="/tmp/simplejson-${VERSION}"
+
+rm -rf "${BUILD}"
+tar -xzf "${SRC}" -C /tmp
+
+# A tarball whose top-level directory does not match the declared version means
+# the URL and the ARG have drifted apart. Fail here rather than installing a
+# different release than the one the Dockerfile claims.
+test -d "${BUILD}/simplejson"
+
+# Ask the interpreter where its site-packages is rather than composing the path
+# from the version string: the two agree today, but a differently-configured
+# prefix would silently install into a directory nothing imports from.
+SITE="$("${PYTHON}" -c 'from distutils.sysconfig import get_python_lib; print get_python_lib()')"
+test -n "${SITE}"
+test -d "${SITE}"
+
+rm -rf "${SITE}/simplejson"
+cp -a "${BUILD}/simplejson" "${SITE}/simplejson"
+
+# The speedups are not built; drop the source so the installed package cannot be
+# mistaken for a compiled one.
+rm -f "${SITE}/simplejson/_speedups.c"
+
+# The installed package must be the version asked for.
+GOT="$("${PYTHON}" -c 'import simplejson; print simplejson.__version__')"
+if [ "${GOT}" != "${VERSION}" ]; then
+    echo "FATAL: installed simplejson ${GOT}, expected ${VERSION}" >&2
+    exit 1
+fi
+
+# --- Gate -------------------------------------------------------------------
+# Assert the behaviour an extraction script actually relies on, not merely that
+# the import succeeds. sort_keys is the discriminator between the 2.3-safe and
+# the 2.4-only releases (see the header), so it is exercised on purpose.
+"${PYTHON}" - <<'PY'
+import simplejson
+
+payload = {"b": 2, "a": [1, 2.5, None, True], "s": "plain"}
+encoded = simplejson.dumps(payload, sort_keys=True)
+assert encoded.startswith('{"a"'), encoded
+assert simplejson.loads(encoded) == payload, encoded
+
+# Non-ASCII has to survive the round trip as unicode: Plone content is full of
+# it, and a codec-level break here would only show up on real data.
+text = simplejson.loads('{"k": "\\u00e7\\u00e3o"}')["k"]
+assert isinstance(text, unicode), repr(text)
+assert len(text) == 3, repr(text)
+assert simplejson.loads(simplejson.dumps({"k": text}))["k"] == text
+
+print "simplejson gate ok:", simplejson.__version__
+PY
+
+rm -rf "${BUILD}"


### PR DESCRIPTION
Adds the **Plone 3.2** image — the fifth series of the legacy matrix, and the first port that needs a **new shared script**. #180 established the `legacy/` subtree, the shared scripts and `legacy-build.yml`; #182, #183, #184 added 4.1, 4.0 and 3.3.

These images are for **content extraction, migration rehearsal and archaeology only**. The stacks have known, unpatched security issues and must never be exposed.

Closes #185

## `install-simplejson.sh` arrives

Python grew a stdlib `json` only in **2.6**, so every series below 4.0 needs `simplejson`. But 3.3 — the series immediately above this one — does **not** use this script: its own buildout-cache already ships `simplejson-2.0.9-py2.4.egg` on the instance's `sys.path`. **3.2 is where the install genuinely starts**, and the script covers 1.0 through 3.2 as those land.

Three design points in the script, all deliberate:

- **A plain directory copy into `site-packages`** — no egg, no buildout part, no `.pth`. `site-packages` is on `sys.path` for both script runners (`zopectl run` in the tarball era, `bin/instance run` in the buildout era), so one mechanism covers the whole matrix.
- **The C `_speedups` extension is not built.** simplejson ships a complete pure-Python fallback, these images are for archaeology rather than throughput, and skipping it keeps a compiler out of the loop. `_speedups.c` is then deleted so the install cannot be mistaken for a compiled one.
- **It gates on behaviour, not on import.** The release is not interchangeable between interpreters: 2.0.9 needs Python 2.4's `list.sort(key=...)`, so on 2.3 `dumps(sort_keys=True)` raises `TypeError` while *every other call still works*. The gate exercises `sort_keys` and a non-ASCII unicode round trip on purpose — a wrong pairing is a **build failure here**, not a surprise inside somebody's extraction script months later.

### `fetch-simplejson` is a derived stage, not part of `fetch`

`pybuild` does `COPY --from=fetch /dist /dist`, so folding the simplejson download into `fetch` would invalidate the interpreter build every time the pin moved — recompiling CPython 2.4 from source, under emulation on an arm64 host. Deriving a stage leaves `fetch` byte-identical so `pybuild` stays cached, and reuses the `curl` already installed there. For the same reason the install runs **last** in the build stage with its `ARG` declared there rather than at the top.

## What differs from 3.3

| | 3.3 | 3.2 |
|---|---|---|
| Plone | 3.3.6 | **3.2.3** |
| Zope | 2.10.13 | **2.10.7** |
| Python | 2.4.6 | 2.4.6 |
| JSON | `simplejson` 2.0.9, **bundled** in the cache | `simplejson` 2.0.9, **installed** into `site-packages` |
| Shared scripts | 6, all present | **7** — adds `install-simplejson.sh` |

Everything else is identical: same buildout-era entrypoint, same build and runtime dependencies, same interpreter.

Source: `https://launchpad.net/plone/3.2/3.2.3/+download/Plone-3.2.3-UnifiedInstaller.tgz`

## Verification

| Check | Result |
|---|---|
| `make lint` — hadolint ×6, shellcheck ×9, yq | pass |
| Base smoke test (`SMOKE_CREATE_SITE=1`) | pass, 6/6 gates |
| `-demo` build + `make test-demo-3.2` | pass, 6/6 gates |
| `make -n` on all four targets, GNU Make 3.81 | correct, incl. the stem trap |

The new script is in the `shellcheck shared/*.sh` sweep (9 scripts now, up from 8) and its layer appears in the build graph, so it is genuinely wired in rather than merely added to the tree.

Version claims were read out of the built image rather than assumed:

```
Plone-3.2.3-py2.4.egg
/app/Zope-2.10.7-final-py2.4
Python 2.4.6
simplejson 2.0.9 -> /opt/python2.4/lib/python2.4/site-packages/simplejson/
_speedups.c       -> absent
```

That `site-packages` path is the substantive one: it resolves there rather than to the buildout cache, which is exactly what distinguishes this series from 3.3.

**Cold-build status:** the local build was cache hits off the source repository, so the cold build happens for the first time in CI — same as every series so far.

## Two `legacy/README.md` corrections

Both are made *necessary* by this series rather than merely desirable, so they ride along here:

- `install-simplejson.sh` moves from the "not yet ported" sentence into the **shared scripts table**; that sentence drops from three pending scripts to two (`build-elementtree.sh`, `docker-entrypoint.sh`).
- The **JSON section** said *"Python 2.7 has a stdlib `json`, so 4.2 needs nothing extra"*. With two simplejson series now in the matrix, that reads as though 4.0 and 4.1 need something. It now names **2.6** as where stdlib `json` arrives, and distinguishes 3.3 (bundled) from 3.2 and earlier (installed) — the same distinction the matrix column now carries.

This was flagged as a follow-up on #200. Happy to split it into its own PR if you would rather keep this one to the image alone.

## Follow-ups

- Six series remain: #186 (3.1), #187 (3.0), #194 (2.5), #195 (2.1), #196 (2.0), #197 (1.0). **#186 (3.1) should be the cheapest yet** — buildout era, and every script it needs is now present. **#187 (3.0) is the seam**: first tarball-era entrypoint, and the last unported scripts (`build-elementtree.sh`, `docker-entrypoint.sh`) both arrive with it.
- `legacy/README.md` still shows only the local `plone-legacy:4.2` tags in its quick start, not the published `plone/plone:4.2`. Carried over from #182.
- `legacy/README.md`'s era paragraph and quick-start examples still name 4.2 alone, though the matrix now spans 3.2 – 4.2.
