### PR TITLE
Add the Plone 3.1 legacy image

### DIFF
--- a/.github/workflows/legacy-build.yml
+++ b/.github/workflows/legacy-build.yml
@@ -37,6 +37,9 @@ jobs:
               - 'legacy/demo/**'
               - 'legacy/Makefile'
               - '.github/workflows/legacy-build.yml'
+            v3.1:
+              - *shared
+              - 'legacy/3.1/**'
             v3.2:
               - *shared
               - 'legacy/3.2/**'
@@ -61,7 +64,7 @@ jobs:
           BUILD_ALL: ${{ github.event_name != 'pull_request' }}
         run: |
           # Implemented versions; append when a new directory lands.
-          ALL='["3.2","3.3","4.0","4.1","4.2"]'
+          ALL='["3.1","3.2","3.3","4.0","4.1","4.2"]'
           if [ "${BUILD_ALL}" = "true" ]; then
             VERSIONS="${ALL}"
           else

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
 # Changelog
+- Add Plone 3.1 image to the legacy matrix. Refs #186
+  [@ericof]
 - Add Plone 3.2 image to the legacy matrix. Refs #185
   [@ericof]
 - Add Plone 3.3 image to the legacy matrix. Refs #184

--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ listed; earlier point releases remain in the repository and on Docker Hub.
 | 4.0.9 | 2.6.9 | Debian *(legacy)* | [`legacy/4.0/Dockerfile`](legacy/4.0/Dockerfile) | `4.0`, `4.0.9`, `4.0-demo`, `4.0.9-demo` |
 | 3.3.6 | 2.4.6 | Debian *(legacy)* | [`legacy/3.3/Dockerfile`](legacy/3.3/Dockerfile) | `3.3`, `3.3.6`, `3.3-demo`, `3.3.6-demo` |
 | 3.2.3 | 2.4.6 | Debian *(legacy)* | [`legacy/3.2/Dockerfile`](legacy/3.2/Dockerfile) | `3.2`, `3.2.3`, `3.2-demo`, `3.2.3-demo` |
+| 3.1.7 | 2.4.6 | Debian *(legacy)* | [`legacy/3.1/Dockerfile`](legacy/3.1/Dockerfile) | `3.1`, `3.1.7`, `3.1-demo`, `3.1.7-demo` |
 
 ### Where the tags live
 

--- a/legacy/3.1/Dockerfile
+++ b/legacy/3.1/Dockerfile
@@ -1,0 +1,160 @@
+# syntax=docker/dockerfile:1
+#
+# Plone 3.1.x — FIRST buildout-era image (Zope 2.10.x / Python 2.4.x)
+#
+# Strategy:
+#   Stage 1 (fetch): modern userland downloads everything (old TLS never touches network)
+#   Stage 2 (build): Python 2.4 + PIL, then an OFFLINE buildout from the
+#                    UnifiedInstaller's bundled buildout-cache
+#   Stage 3 (runtime): slim image, non-root, /data volume, port 8080
+#
+# [V 2026-08-20] Why this is not a tarball image, despite 3.1 being listed as
+# "tarball" in the matrix: there is no full Plone-3.1.x.tar.gz anywhere.
+# dist.plone.org carries only PloneBase-3.1.x (the stripped core, without
+# dependency products) and its /release/ tree begins at 3.2. The UnifiedInstaller
+# is the only complete published source for 3.1.7, and it is buildout-based.
+#
+# NOT FOR PRODUCTION. Zope 2.10 has known, unpatched security issues.
+# Intended for content extraction, migration, and archaeology only.
+
+ARG PYTHON_VERSION=2.4.6
+ARG PLONE_VERSION=3.1.7
+ARG PIL_VERSION=1.1.6
+# Zope is NOT fetched separately here: the installer's buildout-cache ships
+# Zope-2.10.6-final.tgz and plone.recipe.zope2install builds it during buildout.
+ARG ZOPE_VERSION=2.10.6
+
+ARG PYTHON_URL=https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz
+# [V 2026-08-20] Verified downloadable (34.9 MB gzip). Launchpad is the only
+# host serving the 3.1.7 UnifiedInstaller; dist.plone.org has no equivalent.
+ARG PLONE_URL=https://launchpad.net/plone/3.1/${PLONE_VERSION}/+download/Plone-${PLONE_VERSION}-UnifiedInstaller.tgz
+ARG PIL_URL=https://dist.plone.org/thirdparty/PIL-${PIL_VERSION}.tar.gz
+
+# --- simplejson -------------------------------------------------------------
+# Python has no stdlib `json` before 2.6, so every image below 4.0 ships
+# simplejson instead. The release is NOT interchangeable between interpreters
+# — see the header of shared/install-simplejson.sh, and note that the install
+# gate will fail the build on a wrong pairing rather than let it through.
+ARG SIMPLEJSON_VERSION=2.0.9
+ARG SIMPLEJSON_URL=https://files.pythonhosted.org/packages/source/s/simplejson/simplejson-${SIMPLEJSON_VERSION}.tar.gz
+
+# ---------------------------------------------------------------------------
+# Stage 1: fetch — modern TLS, nothing else
+# ---------------------------------------------------------------------------
+FROM debian:bookworm-slim AS fetch
+ARG PYTHON_URL
+ARG PLONE_URL
+ARG PIL_URL
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates curl \
+ && rm -rf /var/lib/apt/lists/*
+WORKDIR /dist
+RUN curl -fSL "${PYTHON_URL}" -o python.tgz \
+ && curl -fSL "${PLONE_URL}"  -o installer.tgz \
+ && curl -fSL "${PIL_URL}"    -o pil.tar.gz
+
+# ---------------------------------------------------------------------------
+# Stage 1b: fetch-simplejson — derived from fetch, deliberately not part of it
+# ---------------------------------------------------------------------------
+# pybuild does `COPY --from=fetch /dist /dist`, so folding this download into
+# stage 1 would invalidate the interpreter build every time the simplejson pin
+# moves and recompile CPython from source — hours, under emulation on an arm64
+# host. Deriving a stage leaves `fetch` byte-identical, so pybuild stays cached,
+# and reuses the curl and ca-certificates already installed there. WORKDIR
+# /dist is inherited, so the tarball lands beside the others.
+FROM fetch AS fetch-simplejson
+ARG SIMPLEJSON_URL
+RUN curl -fSL --retry 5 --retry-delay 5 "${SIMPLEJSON_URL}" -o simplejson.tar.gz
+
+# ---------------------------------------------------------------------------
+# Stage 2a: pybuild — Python 2.4 only (gate G1)
+# ---------------------------------------------------------------------------
+FROM debian:bookworm AS pybuild
+ARG PYTHON_VERSION
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      gcc make libc6-dev zlib1g-dev libcrypt-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=fetch /dist /dist
+COPY shared/build-python2.sh /usr/local/bin/build-python2.sh
+
+RUN build-python2.sh /dist/python.tgz "${PYTHON_VERSION}" /opt/python2.4
+
+# ---------------------------------------------------------------------------
+# Stage 2b: build — PIL, then the offline buildout.
+# ---------------------------------------------------------------------------
+FROM pybuild AS build
+ARG PLONE_VERSION
+ARG PIL_VERSION
+
+# bzip2: the buildout-cache is a .tar.bz2.
+# The rest are Zope 2.10's build deps — plone.recipe.zope2install compiles Zope
+# from the cached tarball during buildout, so the toolchain must be present.
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends libjpeg62-turbo-dev bzip2 \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY shared/build-pil.sh /usr/local/bin/build-pil.sh
+RUN build-pil.sh /dist/pil.tar.gz "${PIL_VERSION}" /opt/python2.4/bin/python2.4
+
+# ElementTree is NOT installed separately here: the buildout-cache ships an
+# elementtree egg and the template's buildout.cfg already lists it under eggs.
+COPY shared/build-plone-buildout.sh /usr/local/bin/build-plone-buildout.sh
+RUN build-plone-buildout.sh /dist/installer.tgz "${PLONE_VERSION}" \
+      /opt/python2.4/bin/python2.4 /app
+
+# --- simplejson -------------------------------------------------------------
+# Last in the stage, and with its ARG declared here rather than at the top, so
+# that moving the pin does not invalidate the PIL and Plone layers above.
+# site-packages lives under /opt/python2.4, which stage 3 copies wholesale, so
+# nothing further is needed at runtime.
+ARG SIMPLEJSON_VERSION
+COPY --from=fetch-simplejson /dist/simplejson.tar.gz /dist/simplejson.tar.gz
+COPY shared/install-simplejson.sh /usr/local/bin/install-simplejson.sh
+RUN install-simplejson.sh /dist/simplejson.tar.gz "${SIMPLEJSON_VERSION}" \
+      /opt/python2.4/bin/python2.4
+
+# ---------------------------------------------------------------------------
+# Stage 3: runtime
+# ---------------------------------------------------------------------------
+FROM debian:bookworm-slim
+ARG PLONE_VERSION
+ARG ZOPE_VERSION
+ARG PYTHON_VERSION
+
+LABEL org.opencontainers.image.title="Plone ${PLONE_VERSION} (legacy)" \
+      org.opencontainers.image.description="Plone ${PLONE_VERSION} on Zope ${ZOPE_VERSION} / Python ${PYTHON_VERSION}. Migration and content-extraction use only — NOT for production." \
+      org.opencontainers.image.vendor="Simples Consultoria"
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends zlib1g libcrypt1 libjpeg62-turbo \
+ && rm -rf /var/lib/apt/lists/* \
+ && useradd --system -m -d /app -U -u 500 plone \
+ && mkdir -p /data \
+ && chown -R plone:plone /data
+
+COPY --from=build --chown=plone:plone /opt/python2.4 /opt/python2.4
+COPY --from=build --chown=plone:plone /app /app
+COPY --chown=plone:plone shared/docker-entrypoint-buildout.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+COPY --chown=plone:plone shared/upgrade-plone.py /app/upgrade-plone.py
+COPY --chown=plone:plone shared/configure-zeo.sh /app/configure-zeo.sh
+RUN chmod +x /app/configure-zeo.sh
+
+ENV INSTANCE_HOME=/app/instance \
+    PYTHON=/opt/python2.4/bin/python2.4 \
+    ZOPE_HTTP_PORT=8080
+
+VOLUME /data
+EXPOSE 8080
+WORKDIR /app/instance
+USER plone
+
+# Plone 3.1 registers a large ZCML tree at first start; allow a long warm-up.
+HEALTHCHECK --interval=10s --timeout=5s --start-period=180s --retries=6 \
+  CMD ["/opt/python2.4/bin/python2.4", "-c", "import urllib; urllib.urlopen('http://127.0.0.1:8080/')"]
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["start"]

--- a/legacy/3.1/README.md
+++ b/legacy/3.1/README.md
@@ -1,0 +1,98 @@
+# Plone 3.1 legacy image
+
+Plone 3.1.7 on Zope 2.10.6 / Python 2.4.6. **The first buildout-era image.**
+
+**Not for production.** Zope 2.10 has known, unpatched vulnerabilities. This
+image exists for content extraction, migration rehearsal, and historical
+inspection.
+
+## Why this is a buildout image, though the matrix said "tarball"
+
+There is no full `Plone-3.1.x.tar.gz`. Anywhere.
+
+- `dist.plone.org` carries only `PloneBase-3.1.x` — the **stripped core**, with
+  no dependency products. The repo convention is to always use a full bundle.
+- `dist.plone.org/release/`, which does hold complete egg sets, **starts at 3.2**.
+- The last full product bundle published for any series is `Plone-3.0.5.tar.gz`.
+
+The only complete published source for 3.1.7 is the **UnifiedInstaller** on
+Launchpad, and it is buildout-based. So 3.1 is where the tarball template ends,
+one release earlier than the matrix predicted.
+
+That turns out to be good news for determinism: the installer ships
+`packages/buildout-cache.tar.bz2`, a **complete offline cache** — every
+old-style product tarball, `Zope-2.10.6-final.tgz`, and pre-built py2.4 eggs
+including `zc.buildout` and every `plone.recipe.*`. The build never touches the
+network after the fetch stage, which matters because this toolchain cannot
+negotiate modern TLS. This is the offline egg cache decision D5 anticipated —
+already solved upstream, not something we had to invent.
+
+The install sequence in `shared/build-plone-buildout.sh` is taken from the
+installer's own `helper_scripts/standalone-mode.sh`, not improvised: copy
+`standalone_template`, substitute `__TARGET__` / `__PASSWORD__`, strip the
+root-only `chown` commands, then run `bin/buildout -No` (`-N` don't seek newer,
+`-o` **offline**).
+
+## Usage
+
+```sh
+docker build -f 3.1/Dockerfile -t plone-legacy:3.1.7 .
+docker run -d -p 8080:8080 -e ADMIN_PASSWORD=secret \
+    -v plone31-data:/data plone-legacy:3.1.7
+```
+
+| | |
+|---|---|
+| Port | 8080 (`ZOPE_HTTP_PORT` to change) |
+| Volume | `/data` (`filestorage/Data.fs`, `log/`) |
+| User | `plone` (uid 500) |
+| Env | `ADMIN_USER`, `ADMIN_PASSWORD` (first run only) |
+| PIL | 1.1.6, with JPEG + PNG |
+| ElementTree | from the buildout cache (an egg, not a separate install) |
+
+## Validated facts / hypotheses
+
+- **[V 2026-08-20]** The offline buildout works: `bin/buildout -No` completes,
+  compiles Zope 2.10.6 from the cached tarball, and produces `bin/instance`,
+  `parts/plone` and `var` — the three things the vendor installer itself checks.
+- **[V 2026-08-20]** The shipped `bin/buildout` is **regenerated, not patched**.
+  It hardcodes `#!__TARGET__/Python-2.4/bin/python` and references
+  `setuptools-0.6c8-py2.4.egg`, but the cache actually ships **0.6c9** — that
+  path does not exist, and `install.sh` only gets away with it because it
+  installs setuptools into the interpreter separately. The script discovers the
+  real egg names from the cache instead, which is self-correcting across
+  versions.
+- **[V 2026-08-20]** A buildout instance needs a **different entrypoint**:
+  `zope.conf` and `inituser` live under `parts/instance/` (both *generated* by
+  `plone.recipe.zope2instance`), and the runner is `bin/instance fg`, not
+  `bin/runzope`. Hence `shared/docker-entrypoint-buildout.sh`.
+- **[V 2026-08-20]** The generated `inituser` is **not plaintext** — it is
+  `admin:{SHA}<base64>`. The entrypoint therefore reuses Zope's own
+  `parts/zope2/utilities/zpasswd.py` rather than reimplementing the hash.
+- **[V 2026-08-20]** `var/filestorage` and `var/log` are **symlinked** to
+  `/data/...` at build time rather than rewriting `zope.conf`. `zope.conf` is
+  generated and any later buildout run would overwrite an in-place edit; the
+  symlink survives. Same approach as the official `plone/plone.docker` images.
+- **[V 2026-08-20]** The `[unifiedinstaller]` part is deliberately left in.
+  Removing it from `parts` does **not** stop it — buildout still reports
+  "Installing unifiedinstaller" and generates `bin/plonectl`, because the
+  section is reached through another part's references. Keeping a sed that looks
+  effective and is not would be worse; `bin/plonectl` is simply unused here.
+- **[V 2026-08-20]** **A gate was silently vacuous and is now fixed.** The
+  smoke test's product-load check grepped `/data/log/event.log`, which is the
+  *tarball-era* name; buildout instances write `instance.log`. 3.1's first
+  "OK: no product import/install errors" was therefore checking a file that did
+  not exist. `shared/smoke-test.sh` now globs `/data/log/*.log` and **fails if
+  it finds no log at all**, so a future rename breaks the build instead of
+  quietly disabling the gate.
+- **[V 2026-08-20]** With the check actually reading
+  `instance.log` + `instance-Z2.log`: zero product import/install errors, and a
+  Plone 3.1 site can be created and rendered (~20 kB with the Plone `generator`
+  meta tag). Passes twice consecutively.
+
+## Smoke test (CI gate)
+
+```sh
+make test-3.1                      # HTTP + auth + every product loads
+SMOKE_CREATE_SITE=1 make test-3.1  # also creates a Plone site and checks its markup
+```

--- a/legacy/Makefile
+++ b/legacy/Makefile
@@ -14,7 +14,7 @@ PLATFORM ?= linux/amd64
 # the matrix in README.md, and the ALL list in
 # ../.github/workflows/legacy-build.yml. One series lands per pull request;
 # append here as each one is ported.
-SERIES := 3.2 3.3 4.0 4.1 4.2
+SERIES := 3.1 3.2 3.3 4.0 4.1 4.2
 
 # Builder used for the -demo images, which MUST be a `docker`-driver one:
 # demo/Dockerfile's FROM reads the base image out of the local image store, and
@@ -42,6 +42,7 @@ DEMO_TEST_PASSWORD ?= smoke-not-admin
 # these images are built from.
 # [V 2026-08-20] 4.1.6 is both the final 4.1.x release and the last
 # UnifiedInstaller published for the series, so this row needs no compromise.
+FULL_VERSION_3.1 := 3.1.7
 FULL_VERSION_3.2 := 3.2.3
 FULL_VERSION_3.3 := 3.3.6
 # [V 2026-08-20] 4.0.9, not 4.0.10: 4.0.10 is the final release and its egg

--- a/legacy/README.md
+++ b/legacy/README.md
@@ -17,9 +17,10 @@ They exist for content extraction, migration rehearsal, and archaeology.
 | 4.0  | 4.0.9 | 2.12.19 | 2.6.9  | buildout | stdlib `json` | **done** |
 | 3.3  | 3.3.6 | 2.10.13 | 2.4.6  | buildout | `simplejson` 2.0.9 (bundled) | **done** |
 | 3.2  | 3.2.3 | 2.10.7  | 2.4.6  | buildout | `simplejson` 2.0.9 (installed) | **done** |
+| 3.1  | 3.1.7 | 2.10.6  | 2.4.6  | buildout | `simplejson` 2.0.9 (installed) | **done** |
 
 The matrix extends down to Plone 1.0. One series lands per pull request; the
-remaining six follow these. When adding a series, keep four places in sync:
+remaining five follow these. When adding a series, keep four places in sync:
 the directory, the table above, `SERIES` and `FULL_VERSION_*` in the
 [`Makefile`](Makefile), and the paths-filter list plus `ALL` in
 [`../.github/workflows/legacy-build.yml`](../.github/workflows/legacy-build.yml).


### PR DESCRIPTION
Adds the **Plone 3.1** image — the sixth series of the legacy matrix, and the cheapest port so far. #180 established the `legacy/` subtree, the shared scripts and `legacy-build.yml`; #182, #183, #184, #185 added 4.1, 4.0, 3.3 and 3.2.

These images are for **content extraction, migration rehearsal and archaeology only**. The stacks have known, unpatched security issues and must never be exposed.

Closes #186

## No new shared scripts

3.1 uses the same **seven** as 3.2, including `install-simplejson.sh`, which landed with that series. The closure trace comes back fully satisfied — nothing to port.

## A buildout image, despite 3.1 being listed as "tarball" in the matrix

No full `Plone-3.1.x.tar.gz` was ever published. `dist.plone.org` carries only `PloneBase-3.1.x` — the stripped core, without dependency products — and its `/release/` tree begins at **3.2**. The UnifiedInstaller is the only complete published source for 3.1.7, and it is buildout-based.

### 3.1 is the last series where Plone is a Zope *product*, not an egg

| | 3.2 and up | **3.1** |
|---|---|---|
| Zope | `/app/Zope-2.10.7-final-py2.4` | `/app/instance/parts/zope2` |
| Plone | `Plone-3.2.3-py2.4.egg` in the cache | `parts/plone/CMFPlone` — a product |

That's the `base_skeleton` + `buildout_templates` change introduced *after* 3.1. `build-plone-buildout.sh` already handles both shapes with no per-version branch, and the smoke gate's *"no product import/install errors"* check passes on the older layout too.

**ElementTree is likewise not installed separately** — the buildout-cache ships `elementtree-1.2.7_20070827_preview-py2.4.egg` and the template's `buildout.cfg` already lists it. That's why `build-elementtree.sh` is **3.0-only** rather than "Plone 3", and it stays unported until #187.

## What differs from 3.2

| | 3.2 | 3.1 |
|---|---|---|
| Plone | 3.2.3 | **3.1.7** |
| Zope | 2.10.7 | **2.10.6** |
| Python | 2.4.6 | 2.4.6 |
| JSON | `simplejson` 2.0.9, installed | same |
| Instance layout | `base_skeleton` + eggs | **products under `parts/`** |

Source: `https://launchpad.net/plone/3.1/3.1.7/+download/Plone-3.1.7-UnifiedInstaller.tgz`

## Ported verbatim, including a known `curl --retry` gap

Every series from 3.2 up passes `--retry 5 --retry-delay 5` on its downloads, because — as those Dockerfiles document — *Launchpad intermittently answers 503 under load, and a transient failure here wastes the whole build*. 3.1's fetch stage does **not**, though it fetches its installer from Launchpad too:

| Series | curl calls with `--retry` |
|---|---|
| 3.2, 3.3, 4.0, 4.1, 4.2 | all |
| **3.1** (and 1.0–3.0 upstream) | only the `fetch-simplejson` one |

That's an artefact of the order the upstream Dockerfiles were written, not a decision about 3.1. **Deliberately not fixed here**: keeping the ported file byte-identical to `plone-legacy/3.1/Dockerfile` is worth more than the one-line change, and the gap is better closed for 1.0–3.1 in a single pass. Tracked separately.

The practical consequence is that this PR's CI run has a small chance of a spurious red on a Launchpad hiccup. A re-run is the remedy until the sweep lands.

## Verification

| Check | Result |
|---|---|
| `make lint` — hadolint ×7, shellcheck ×9, yq | pass |
| Base smoke test (`SMOKE_CREATE_SITE=1`) | pass, 6/6 gates |
| `-demo` build + `make test-demo-3.1` | pass, 6/6 gates |
| `make -n` on all four targets, GNU Make 3.81 | correct, incl. the stem trap |

Version claims were read out of the built image rather than assumed — and for this series that meant looking in different places than for 3.2:

```
parts/plone/CMFPlone/version.txt      -> 3.1.7
App.version_txt.getZopeVersion()      -> (2, 10, 6, '', -1)
python2.4 -V                          -> Python 2.4.6
simplejson                            -> 2.0.9, in site-packages
elementtree-1.2.7_20070827_preview-py2.4.egg  (from the cache, not installed by us)
```

**Cold-build status:** the local build was cache hits off the source repository, so the cold build happens for the first time in CI — same as every series so far.

## Follow-ups

- Five series remain: #187 (3.0), #194 (2.5), #195 (2.1), #196 (2.0), #197 (1.0). **#187 (3.0) is the seam** — the first tarball-era entrypoint, and both remaining unported scripts (`build-elementtree.sh`, `docker-entrypoint.sh`) arrive with it.
- **`curl --retry` sweep for 1.0–3.1**, per the section above.
- `legacy/README.md` still shows only the local `plone-legacy:4.2` tags in its quick start, not the published `plone/plone:4.2`. Carried over from #182.
- `legacy/README.md`'s era paragraph and quick-start examples still name 4.2 alone, though the matrix now spans 3.1 – 4.2.
