### PR TITLE
Expand the legacy series-wiring checklist from four places to eight

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
 # Changelog
+- Expand the legacy series-wiring checklist in legacy/README.md from four places to eight. Refs #204
+  [@ericof]
 - Add Plone 3.0 image to the legacy matrix. Refs #187
   [@ericof]
 - Add Plone 3.1 image to the legacy matrix. Refs #186

--- a/legacy/README.md
+++ b/legacy/README.md
@@ -21,10 +21,27 @@ They exist for content extraction, migration rehearsal, and archaeology.
 | 3.0  | 3.0.5 | 2.10.13 | 2.4.6  | tarball  | `simplejson` 2.0.9 (installed) | **done** |
 
 The matrix extends down to Plone 1.0. One series lands per pull request; the
-remaining four follow these. When adding a series, keep four places in sync:
-the directory, the table above, `SERIES` and `FULL_VERSION_*` in the
-[`Makefile`](Makefile), and the paths-filter list plus `ALL` in
-[`../.github/workflows/legacy-build.yml`](../.github/workflows/legacy-build.yml).
+remaining four follow these.
+
+Adding a series touches eight places. Miss one and the build still passes — the
+image is simply never built, or the docs quietly disagree with what ships — so
+the list is worth working through rather than recalling:
+
+1. `<version>/Dockerfile`
+2. `<version>/README.md`, carrying that version's validated/hypothesised ledger
+3. `SERIES` in the [`Makefile`](Makefile), oldest first
+4. `FULL_VERSION_<version>` in the [`Makefile`](Makefile)
+5. the paths-filter `v<version>` entry in
+   [`../.github/workflows/legacy-build.yml`](../.github/workflows/legacy-build.yml)
+6. the `ALL` list in that same workflow — **separate from the filter**, and the
+   one that decides what a push to `main` builds
+7. the table above, including its "remaining N" count, **and** the image table
+   in [`../README.md`](../README.md)
+8. a [`../CHANGES.md`](../CHANGES.md) entry
+
+Then `make lint`, `make -n` on all four targets for the new series (see the
+GNU Make 3.81 note in the Makefile), and both smoke gates —
+`SMOKE_CREATE_SITE=1 make test-<version>` and `make test-demo-<version>`.
 
 The point release is what is actually *buildable*, which is not always the last
 release. **4.2.6, not the final 4.2.7**: no UnifiedInstaller was ever published


### PR DESCRIPTION
`legacy/README.md` told contributors to *"keep four places in sync"* when adding a series. That undercounted it.

The sentence named the directory, the matrix table, the Makefile and the workflow — and omitted:

- the version's own `README.md` (its validated/hypothesised ledger)
- the image table in the root `README.md`
- the `CHANGES.md` entry
- the matrix table's own "remaining N follow these" count

It also collapsed the workflow's **paths-filter entry** and its **`ALL` list** into a single item, though they are separate edits in different parts of the file, with different consequences.

## Why it matters

**Missing an entry does not break the build**, which is exactly why the list needs to be right:

| Omission | Symptom |
|---|---|
| `ALL` entry | the image is simply never built on pushes to `main` — CI stays green |
| paths-filter entry | the series is never rebuilt when shared code changes |
| a table row | the docs quietly disagree with what actually ships |

All three are silent. Nothing turns red.

## Evidence

Seven series have now been ported against that sentence (#180, #182, #183, #184, #185, #186, #187). Each port recovered the real list from the *previous port's commit diff* rather than from the document meant to carry it — which works, but only because there was always a previous port to copy from.

## The change

The sentence becomes a numbered list of the eight places, with the two workflow edits split apart and the silent-failure mode named. It also records the verification steps that follow: `make lint`, `make -n` on all four targets for the new series (the GNU Make 3.81 stem trap), and both smoke gates — `SMOKE_CREATE_SITE=1 make test-<version>` and `make test-demo-<version>`.

Docs only — no Dockerfile, Makefile or workflow changes. Four series remain to be ported (#194, #195, #196, #197), all copy-and-wire, so this lands before they do.
