### PR TITLE
Add the Plone 2.5 legacy image

### DIFF
--- a/.github/workflows/legacy-build.yml
+++ b/.github/workflows/legacy-build.yml
@@ -37,6 +37,9 @@ jobs:
               - 'legacy/demo/**'
               - 'legacy/Makefile'
               - '.github/workflows/legacy-build.yml'
+            v2.5:
+              - *shared
+              - 'legacy/2.5/**'
             v3.0:
               - *shared
               - 'legacy/3.0/**'
@@ -67,7 +70,7 @@ jobs:
           BUILD_ALL: ${{ github.event_name != 'pull_request' }}
         run: |
           # Implemented versions; append when a new directory lands.
-          ALL='["3.0","3.1","3.2","3.3","4.0","4.1","4.2"]'
+          ALL='["2.5","3.0","3.1","3.2","3.3","4.0","4.1","4.2"]'
           if [ "${BUILD_ALL}" = "true" ]; then
             VERSIONS="${ALL}"
           else

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
 # Changelog
+- Add Plone 2.5 image to the legacy matrix. Refs #194
+  [@ericof]
 - Expand the legacy series-wiring checklist in legacy/README.md from four places to eight. Refs #204
   [@ericof]
 - Add Plone 3.0 image to the legacy matrix. Refs #187

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ listed; earlier point releases remain in the repository and on Docker Hub.
 | 3.2.3 | 2.4.6 | Debian *(legacy)* | [`legacy/3.2/Dockerfile`](legacy/3.2/Dockerfile) | `3.2`, `3.2.3`, `3.2-demo`, `3.2.3-demo` |
 | 3.1.7 | 2.4.6 | Debian *(legacy)* | [`legacy/3.1/Dockerfile`](legacy/3.1/Dockerfile) | `3.1`, `3.1.7`, `3.1-demo`, `3.1.7-demo` |
 | 3.0.5 | 2.4.6 | Debian *(legacy)* | [`legacy/3.0/Dockerfile`](legacy/3.0/Dockerfile) | `3.0`, `3.0.5`, `3.0-demo`, `3.0.5-demo` |
+| 2.5.4-2 | 2.4.6 | Debian *(legacy)* | [`legacy/2.5/Dockerfile`](legacy/2.5/Dockerfile) | `2.5`, `2.5.4-2`, `2.5-demo`, `2.5.4-2-demo` |
 
 ### Where the tags live
 

--- a/legacy/2.5/Dockerfile
+++ b/legacy/2.5/Dockerfile
@@ -1,0 +1,201 @@
+# syntax=docker/dockerfile:1
+#
+# Plone 2.5.x — tarball era (Zope 2.9.x / Python 2.4.x)
+#
+# Strategy:
+#   Stage 1 (fetch): modern userland downloads everything (old TLS never touches network)
+#   Stage 2 (build): compile Python 2.4 + PIL + Zope 2.9 on bookworm (gcc 12: warns, doesn't error)
+#   Stage 3 (runtime): slim image, non-root, /data volume, port 8080
+#
+# The Python and PIL builds live in shared/build-python2.sh and
+# shared/build-pil.sh, which every tarball-era image uses. Their inline
+# comments carry the reasoning for each mitigation.
+#
+# NOT FOR PRODUCTION. Zope 2.9 has known, unpatched security issues.
+# Intended for content extraction, migration, and archaeology only.
+
+ARG PYTHON_VERSION=2.4.6
+ARG ZOPE_VERSION=2.9.12
+# [V 2026-08-20] There is no Plone 2.5.5. dist.plone.org has no 2.5.5 in
+# /archive/, /download/ or /packages/; the last 2.5.x is 2.5.4, published as
+# two tarballs with identical file lists. Plone-2.5.4-2.tar.gz is the later
+# roll (2007-10-09 12:44 vs 08:07): it adds the 2.5.4-final -> 2.5.4-2 upgrade
+# path in CMFPlone/migrations and corrects an ATContentTypes version string
+# from "1.1.7-devel (svn/unreleased)" to "1.1.7-final". Its version.txt reads
+# "2.5.4-2", which is why the image tag carries the -2 as well.
+ARG PLONE_VERSION=2.5.4-2
+# [V 2026-08-20] CMFPlone 2.5.4 utils.py line 6 is an unconditional
+# `from PIL import Image`, exactly as in 2.1.4 — so PIL is a hard requirement
+# here too, not an image-scaling nicety (decisions D2/D4).
+ARG PIL_VERSION=1.1.6
+
+# [V 2026-08-20] Verified: Zope-2.9.12-final.tgz (7.1 MB) exists at
+# old.zope.dev and unpacks to Zope-2.9.12-final/ with a top-level ./configure.
+ARG ZOPE_URL=https://old.zope.dev/Products/Zope/${ZOPE_VERSION}/Zope-${ZOPE_VERSION}-final.tgz
+# [V] python.org keeps all historical releases
+ARG PYTHON_URL=https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz
+# [V 2026-08-20] Verified: Plone-2.5.4-2.tar.gz exists at dist.plone.org/archive/
+ARG PLONE_URL=https://dist.plone.org/archive/Plone-${PLONE_VERSION}.tar.gz
+# [V 2026-08-20] effbot.org is dead (404) and PyPI lists PIL but serves no
+# files; dist.plone.org/thirdparty is the surviving canonical source. Note this
+# is the Plone-community repackaging of PIL, not the stock effbot tarball.
+ARG PIL_URL=https://dist.plone.org/thirdparty/PIL-${PIL_VERSION}.tar.gz
+
+# --- simplejson -------------------------------------------------------------
+# Python has no stdlib `json` before 2.6, so every image below 4.0 ships
+# simplejson instead. The release is NOT interchangeable between interpreters
+# — see the header of shared/install-simplejson.sh, and note that the install
+# gate will fail the build on a wrong pairing rather than let it through.
+ARG SIMPLEJSON_VERSION=2.0.9
+ARG SIMPLEJSON_URL=https://files.pythonhosted.org/packages/source/s/simplejson/simplejson-${SIMPLEJSON_VERSION}.tar.gz
+
+# ---------------------------------------------------------------------------
+# Stage 1: fetch — modern TLS, nothing else
+# ---------------------------------------------------------------------------
+FROM debian:bookworm-slim AS fetch
+ARG ZOPE_URL
+ARG PYTHON_URL
+ARG PLONE_URL
+ARG PIL_URL
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates curl \
+ && rm -rf /var/lib/apt/lists/*
+WORKDIR /dist
+RUN curl -fSL "${PYTHON_URL}" -o python.tgz \
+ && curl -fSL "${ZOPE_URL}"   -o zope.tgz \
+ && curl -fSL "${PLONE_URL}"  -o plone.tar.gz \
+ && curl -fSL "${PIL_URL}"    -o pil.tar.gz
+
+# ---------------------------------------------------------------------------
+# Stage 1b: fetch-simplejson — derived from fetch, deliberately not part of it
+# ---------------------------------------------------------------------------
+# pybuild does `COPY --from=fetch /dist /dist`, so folding this download into
+# stage 1 would invalidate the interpreter build every time the simplejson pin
+# moves and recompile CPython from source — hours, under emulation on an arm64
+# host. Deriving a stage leaves `fetch` byte-identical, so pybuild stays cached,
+# and reuses the curl and ca-certificates already installed there. WORKDIR
+# /dist is inherited, so the tarball lands beside the others.
+FROM fetch AS fetch-simplejson
+ARG SIMPLEJSON_URL
+RUN curl -fSL --retry 5 --retry-delay 5 "${SIMPLEJSON_URL}" -o simplejson.tar.gz
+
+# ---------------------------------------------------------------------------
+# Stage 2a: pybuild — Python 2.4 only, so `--target pybuild` is exactly gate G1
+# and a Zope failure cannot deny us a testable interpreter.
+# ---------------------------------------------------------------------------
+FROM debian:bookworm AS pybuild
+ARG PYTHON_VERSION
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      gcc make libc6-dev zlib1g-dev libcrypt-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=fetch /dist /dist
+COPY shared/build-python2.sh /usr/local/bin/build-python2.sh
+
+RUN build-python2.sh /dist/python.tgz "${PYTHON_VERSION}" /opt/python2.4
+
+# ---------------------------------------------------------------------------
+# Stage 2b: build — PIL, Zope 2.9, the Zope instance, and the Plone products.
+# ---------------------------------------------------------------------------
+FROM pybuild AS build
+ARG ZOPE_VERSION
+ARG PLONE_VERSION
+ARG PIL_VERSION
+
+# --- PIL --------------------------------------------------------------------
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends libjpeg62-turbo-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY shared/build-pil.sh /usr/local/bin/build-pil.sh
+RUN build-pil.sh /dist/pil.tar.gz "${PIL_VERSION}" /opt/python2.4/bin/python2.4
+
+# --- Zope 2.9 ---------------------------------------------------------------
+# Same configure + make (distutils underneath) as 2.8. -fcommon avoids gcc>=10
+# "multiple definition" errors from tentative definitions in the old C
+# extensions (ExtensionClass, cAccessControl, ZODB BTrees).
+RUN tar -xzf /dist/zope.tgz -C /tmp \
+ && cd /tmp/Zope-${ZOPE_VERSION}-final \
+ && ./configure --prefix=/opt/zope \
+      --with-python=/opt/python2.4/bin/python2.4 \
+ && CFLAGS="-fcommon -fno-strict-aliasing" make \
+ && make install \
+ && rm -rf /tmp/Zope-${ZOPE_VERSION}-final
+
+# --- Zope instance + Plone products -----------------------------------------
+# Placeholder inituser; the real one is written by the entrypoint at runtime.
+RUN /opt/python2.4/bin/python2.4 /opt/zope/bin/mkzopeinstance.py \
+      --dir /app/instance --user "admin:placeholder"
+
+# [V 2026-08-20] Bundle layout is Plone-2.5.4-2/<ProductName>/..., one dir per
+# product (38 of them), confirmed with `tar -tzf`, so --strip-components=1 is
+# correct — same shape as the 2.1.4 bundle.
+RUN mkdir -p /tmp/plone \
+ && tar -xzf /dist/plone.tar.gz -C /tmp/plone --strip-components=1 \
+ && cp -a /tmp/plone/. /app/instance/Products/ \
+ && test -d /app/instance/Products/CMFPlone \
+ && rm -rf /tmp/plone
+
+# Point the filestorage and logs at /data (populated at runtime).
+RUN sed -i \
+      -e 's|\$INSTANCE/var/Data.fs|/data/filestorage/Data.fs|' \
+      -e 's|\$INSTANCE/log|/data/log|' \
+      /app/instance/etc/zope.conf
+
+# --- simplejson -------------------------------------------------------------
+# Last in the stage, and with its ARG declared here rather than at the top, so
+# that moving the pin does not invalidate the PIL and Plone layers above.
+# site-packages lives under /opt/python2.4, which stage 3 copies wholesale, so
+# nothing further is needed at runtime.
+ARG SIMPLEJSON_VERSION
+COPY --from=fetch-simplejson /dist/simplejson.tar.gz /dist/simplejson.tar.gz
+COPY shared/install-simplejson.sh /usr/local/bin/install-simplejson.sh
+RUN install-simplejson.sh /dist/simplejson.tar.gz "${SIMPLEJSON_VERSION}" \
+      /opt/python2.4/bin/python2.4
+
+# ---------------------------------------------------------------------------
+# Stage 3: runtime
+# ---------------------------------------------------------------------------
+FROM debian:bookworm-slim
+ARG PLONE_VERSION
+ARG ZOPE_VERSION
+ARG PYTHON_VERSION
+
+LABEL org.opencontainers.image.title="Plone ${PLONE_VERSION} (legacy)" \
+      org.opencontainers.image.description="Plone ${PLONE_VERSION} on Zope ${ZOPE_VERSION} / Python ${PYTHON_VERSION}. Migration and content-extraction use only — NOT for production." \
+      org.opencontainers.image.vendor="Simples Consultoria"
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends zlib1g libcrypt1 libjpeg62-turbo \
+ && rm -rf /var/lib/apt/lists/* \
+ && useradd --system -m -d /app -U -u 500 plone \
+ && mkdir -p /data \
+ && chown -R plone:plone /data
+
+COPY --from=build --chown=plone:plone /opt/python2.4 /opt/python2.4
+COPY --from=build --chown=plone:plone /opt/zope /opt/zope
+COPY --from=build --chown=plone:plone /app /app
+COPY --chown=plone:plone shared/docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+COPY --chown=plone:plone shared/upgrade-plone.py /app/upgrade-plone.py
+COPY --chown=plone:plone shared/configure-zeo.sh /app/configure-zeo.sh
+RUN chmod +x /app/configure-zeo.sh
+
+ENV ZOPE_HOME=/opt/zope \
+    INSTANCE_HOME=/app/instance \
+    PYTHON=/opt/python2.4/bin/python2.4 \
+    ZOPE_HTTP_PORT=8080
+
+VOLUME /data
+EXPOSE 8080
+WORKDIR /app
+USER plone
+
+# ZServer is slow to warm up on first start (Data.fs creation + product init)
+HEALTHCHECK --interval=10s --timeout=5s --start-period=120s --retries=5 \
+  CMD ["/opt/python2.4/bin/python2.4", "-c", "import urllib; urllib.urlopen('http://127.0.0.1:8080/')"]
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["start"]

--- a/legacy/2.5/README.md
+++ b/legacy/2.5/README.md
@@ -1,0 +1,82 @@
+# Plone 2.5 legacy image
+
+Plone 2.5.4-2 on Zope 2.9.12 / Python 2.4.6. Tarball-era template (no buildout).
+
+**Not for production.** Zope 2.9 has known, unpatched vulnerabilities. This image
+exists for content extraction, migration rehearsal, and historical inspection.
+
+The image bundles **PIL 1.1.6** with JPEG and PNG support. As in 2.1, this is not
+optional: `CMFPlone/utils.py` line 6 is an unconditional `from PIL import Image`.
+
+## Why the tag says `2.5.4-2`
+
+There is no Plone 2.5.5. The last 2.5.x is 2.5.4, published as two tarballs whose
+file lists are byte-for-byte identical; only four files differ. `Plone-2.5.4-2.tar.gz`
+is the later roll and the one shipped here, so the image tag matches the
+`CMFPlone/version.txt` inside it rather than rounding down to a prettier `2.5.4`.
+
+## Usage
+
+```sh
+docker build -f 2.5/Dockerfile -t plone-legacy:2.5.4-2 .
+docker run -d -p 8080:8080 -e ADMIN_PASSWORD=secret \
+    -v plone25-data:/data plone-legacy:2.5.4-2
+```
+
+To mount an existing site, drop its `Data.fs` at `/data/filestorage/Data.fs`
+(and add its third-party products to `/app/instance/Products` via bind mount
+or a derived image).
+
+| | |
+|---|---|
+| Port | 8080 (`ZOPE_HTTP_PORT` to change) |
+| Volume | `/data` (`filestorage/Data.fs`, `log/`) |
+| User | `plone` (uid 500) |
+| Env | `ADMIN_USER`, `ADMIN_PASSWORD` (first run only) |
+| PIL | 1.1.6, with JPEG + PNG (no freetype/`_imagingft`) |
+
+## Validated facts / hypotheses
+
+- **[V 2026-08-20]** **Plone 2.5.5 does not exist.** `dist.plone.org` has no
+  2.5.5 in `/archive/`, `/download/` or `/packages/`. The matrix's `2.5.5*` was
+  a placeholder and the Makefile pinned a phantom version.
+- **[V 2026-08-20]** The two 2.5.4 tarballs have **identical file lists**; only
+  `CMFPlone/version.txt`, `CONTENTS.txt`, `CMFPlone/migrations/__init__.py` and
+  `ATContentTypes/migration/__init__.py` differ. `-2` (2007-10-09 12:44) is the
+  later roll: it registers the `2.5.4-final -> 2.5.4-2` upgrade path and
+  corrects an ATContentTypes version string from `1.1.7-devel (svn/unreleased)`
+  to `1.1.7-final`. Verified by extracting and diffing both, not by changelog.
+- **[V 2026-08-20]** `Zope-2.9.12-final.tgz` (7.1 MB) is downloadable from
+  `old.zope.dev/Products/Zope/2.9.12/`, unpacks to `Zope-2.9.12-final/`, and
+  ships a top-level `./configure` plus `utilities/mkzopeinstance.py` — the same
+  build shape as 2.8.12, so the 2.1 recipe transfers unchanged.
+- **[V 2026-08-20]** Python 2.4.6 builds via the shared `build-python2.sh`
+  with no 2.5-specific changes; `lib-dynload` has no `*_failed.so`.
+- **[V 2026-08-20]** Bundle layout is `Plone-2.5.4-2/<Product>/...`, 38 product
+  directories (vs. 20 in 2.0.5 and 32 installed in 2.1.4).
+- **[V 2026-08-20]** Zope 2.9.12 C extensions compile with gcc 12 given
+  `CFLAGS="-fcommon -fno-strict-aliasing"`. As with 2.8.12, this confirms the
+  flag is *sufficient*; it was not re-run without `-fcommon`, so necessity is
+  untested.
+- **[V 2026-08-20]** **The site factory differs from 2.1** — this is the
+  ledger's "do not recall, re-discover" warning coming true on the first new
+  version directory:
+
+  | Version | linked from `/manage_main` | form posts to |
+  |---|---|---|
+  | 2.1.4 | `CMFPlone/addSite` | `manage_addSite` |
+  | 2.5.4-2 | `CMFPlone/addPloneSiteForm` | `addPloneSite` |
+
+  `shared/smoke-test.sh` now walks the two steps (find the add-form, read its
+  `action`) instead of hardcoding either, so the gate is version-agnostic.
+  2.5's form also offers `extension_ids:list`, which the test leaves unset.
+- **[V 2026-08-20]** A Plone 2.5 site can be created and rendered: the site
+  root serves ~22 kB carrying the Plone `generator` meta tag, and zero products
+  fail to import or install.
+
+## Smoke test (CI gate)
+
+```sh
+make test-2.5                      # HTTP + auth + every product loads
+SMOKE_CREATE_SITE=1 make test-2.5  # also creates a Plone site and checks its markup
+```

--- a/legacy/Makefile
+++ b/legacy/Makefile
@@ -14,7 +14,7 @@ PLATFORM ?= linux/amd64
 # the matrix in README.md, and the ALL list in
 # ../.github/workflows/legacy-build.yml. One series lands per pull request;
 # append here as each one is ported.
-SERIES := 3.0 3.1 3.2 3.3 4.0 4.1 4.2
+SERIES := 2.5 3.0 3.1 3.2 3.3 4.0 4.1 4.2
 
 # Builder used for the -demo images, which MUST be a `docker`-driver one:
 # demo/Dockerfile's FROM reads the base image out of the local image store, and
@@ -42,6 +42,11 @@ DEMO_TEST_PASSWORD ?= smoke-not-admin
 # these images are built from.
 # [V 2026-08-20] 4.1.6 is both the final 4.1.x release and the last
 # UnifiedInstaller published for the series, so this row needs no compromise.
+# [V 2026-08-20] There is no Plone 2.5.5 on dist.plone.org (nor /download/
+# nor /packages/). The last 2.5.x is 2.5.4, shipped as two tarballs with
+# identical file lists; Plone-2.5.4-2.tar.gz is the later roll (adds the
+# 2.5.4-final -> 2.5.4-2 upgrade path) and its version.txt reads "2.5.4-2".
+FULL_VERSION_2.5 := 2.5.4-2
 # [V 2026-08-20] 3.0.5, not 3.0.6: the 3.0.6 roll shipped only as
 # PloneBase-3.0.6.tar.gz (the stripped core, without dependency products).
 # The last full Plone-*.tar.gz for the series is 3.0.5.

--- a/legacy/README.md
+++ b/legacy/README.md
@@ -19,9 +19,10 @@ They exist for content extraction, migration rehearsal, and archaeology.
 | 3.2  | 3.2.3 | 2.10.7  | 2.4.6  | buildout | `simplejson` 2.0.9 (installed) | **done** |
 | 3.1  | 3.1.7 | 2.10.6  | 2.4.6  | buildout | `simplejson` 2.0.9 (installed) | **done** |
 | 3.0  | 3.0.5 | 2.10.13 | 2.4.6  | tarball  | `simplejson` 2.0.9 (installed) | **done** |
+| 2.5  | 2.5.4-2 | 2.9.12  | 2.4.6  | tarball  | `simplejson` 2.0.9 (installed) | **done** |
 
 The matrix extends down to Plone 1.0. One series lands per pull request; the
-remaining four follow these.
+remaining three follow these.
 
 Adding a series touches eight places. Miss one and the build still passes — the
 image is simply never built, or the docs quietly disagree with what ships — so


### PR DESCRIPTION
Adds the Plone **2.5.4-2** image to the legacy matrix — Zope 2.9.12 / Python 2.4.6, tarball era.

Closes #194

## The first genuinely copy-and-wire port

`legacy/shared/` already carried the whole closure this image needs — `build-python2.sh`, `build-pil.sh`, `install-simplejson.sh`, `docker-entrypoint.sh`, `upgrade-plone.py`, `configure-zeo.sh` — so **no new shared scripts land here**, exactly as #187 predicted when it completed the shared set.

It is also the first series wired against the eight-place checklist from #204 rather than against the previous port's commit diff.

## Why the tag says `2.5.4-2`

There is no Plone 2.5.5 — `dist.plone.org` has no such roll in `/archive/`, `/download/` or `/packages/`. The last 2.5.x is 2.5.4, published as **two tarballs with identical file lists**; `Plone-2.5.4-2.tar.gz` is the later one, registering the `2.5.4-final -> 2.5.4-2` upgrade path and correcting an ATContentTypes version string.

Its `version.txt` reads `2.5.4-2`, so rounding the tag down to a prettier `2.5.4` would make the image disagree with its own contents.

## What is different from the neighbouring series

| | |
|---|---|
| **Zope source** | built from source as in 3.0, but from `old.zope.dev`, not `dist.plone.org` |
| **Bundle layout** | the 2.x shape — one directory per product, `--strip-components=1` — not 3.0's `Products/` + `lib/python/` split |
| **PIL** | a hard requirement, not a nicety: `CMFPlone/utils.py` opens with an unconditional `from PIL import Image` |
| **Site factory** | `addPloneSiteForm` → `addPloneSite`, **not** 2.1's `CMFPlone/addSite` → `manage_addSite` |

That last one needed no code change: `shared/smoke-test.sh` discovers both steps at run time instead of hardcoding either. The run log shows it resolving `addPloneSiteForm -> addPloneSite` on its own — the version-agnostic gate doing its job on a version it had never seen.

## Verification

- `make lint` — 9 Dockerfiles, 11 shell scripts, workflow YAML
- `make -n` on all four 2.5 targets, including the `test-demo-2.5` case the GNU Make 3.81 stem rule would otherwise route to `test-%`
- `SMOKE_CREATE_SITE=1 make test-2.5` — **6/6**, site root 22216 bytes
- `make test-demo-2.5` — **6/6**, build-time password confirmed dead after the `ADMIN_PASSWORD` reset

Versions read **out of the built image**, not from the `ARG`s: `Products/CMFPlone/version.txt` → `2.5.4-2`, interpreter → `2.4.6`, simplejson 2.0.9 in site-packages, `from PIL import Image` succeeds, and `Products/` holds exactly the **38 product directories** the README claims.

## Note on CI

Both the base and demo builds were **fully cache-hit** from the `plone-legacy` checkout locally, so the cold build — CPython 2.4.6, PIL and Zope 2.9.12 all compiled from source — is exercised for the first time in this PR's CI run.

Three series remain after this one: #195 (2.1), #196 (2.0), #197 (1.0).
