### PR TITLE
Add the Plone 2.1 legacy image

### DIFF
--- a/.github/workflows/legacy-build.yml
+++ b/.github/workflows/legacy-build.yml
@@ -37,6 +37,9 @@ jobs:
               - 'legacy/demo/**'
               - 'legacy/Makefile'
               - '.github/workflows/legacy-build.yml'
+            v2.1:
+              - *shared
+              - 'legacy/2.1/**'
             v2.5:
               - *shared
               - 'legacy/2.5/**'
@@ -70,7 +73,7 @@ jobs:
           BUILD_ALL: ${{ github.event_name != 'pull_request' }}
         run: |
           # Implemented versions; append when a new directory lands.
-          ALL='["2.5","3.0","3.1","3.2","3.3","4.0","4.1","4.2"]'
+          ALL='["2.1","2.5","3.0","3.1","3.2","3.3","4.0","4.1","4.2"]'
           if [ "${BUILD_ALL}" = "true" ]; then
             VERSIONS="${ALL}"
           else

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
 # Changelog
+- Add Plone 2.1 image to the legacy matrix. Refs #195
+  [@ericof]
 - Add Plone 2.5 image to the legacy matrix. Refs #194
   [@ericof]
 - Expand the legacy series-wiring checklist in legacy/README.md from four places to eight. Refs #204

--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ listed; earlier point releases remain in the repository and on Docker Hub.
 | 3.1.7 | 2.4.6 | Debian *(legacy)* | [`legacy/3.1/Dockerfile`](legacy/3.1/Dockerfile) | `3.1`, `3.1.7`, `3.1-demo`, `3.1.7-demo` |
 | 3.0.5 | 2.4.6 | Debian *(legacy)* | [`legacy/3.0/Dockerfile`](legacy/3.0/Dockerfile) | `3.0`, `3.0.5`, `3.0-demo`, `3.0.5-demo` |
 | 2.5.4-2 | 2.4.6 | Debian *(legacy)* | [`legacy/2.5/Dockerfile`](legacy/2.5/Dockerfile) | `2.5`, `2.5.4-2`, `2.5-demo`, `2.5.4-2-demo` |
+| 2.1.4 | 2.4.6 | Debian *(legacy)* | [`legacy/2.1/Dockerfile`](legacy/2.1/Dockerfile) | `2.1`, `2.1.4`, `2.1-demo`, `2.1.4-demo` |
 
 ### Where the tags live
 

--- a/legacy/2.1/Dockerfile
+++ b/legacy/2.1/Dockerfile
@@ -1,0 +1,200 @@
+# syntax=docker/dockerfile:1
+#
+# Plone 2.1.x — tarball era (Zope 2.8.x / Python 2.4.x)
+#
+# Strategy:
+#   Stage 1 (fetch): modern userland downloads everything (old TLS never touches network)
+#   Stage 2 (build): compile Python 2.4 + PIL + Zope 2.8 on bookworm (gcc 12: warns, doesn't error)
+#   Stage 3 (runtime): slim image, non-root, /data volume, port 8080
+#
+# The Python and PIL builds live in shared/build-python2.sh and
+# shared/build-pil.sh, which every tarball-era image uses. Their inline
+# comments carry the reasoning for each mitigation.
+#
+# NOT FOR PRODUCTION. Zope 2.8 has known, unpatched security issues.
+# Intended for content extraction, migration, and archaeology only.
+
+ARG PYTHON_VERSION=2.4.6
+ARG ZOPE_VERSION=2.8.12
+ARG PLONE_VERSION=2.1.4
+# [V 2026-08-20] CMFPlone 2.1.4 imports PIL unconditionally, so this is a hard
+# requirement, not an image-scaling nicety. 1.1.6 is contemporary with Plone
+# 2.1.4 (both 2006) and is the version named by decision D4.
+ARG PIL_VERSION=1.1.6
+
+# [V] Verified 2026-08-19: Zope-2.8.12-final.tgz exists at old.zope.dev
+ARG ZOPE_URL=https://old.zope.dev/Products/Zope/${ZOPE_VERSION}/Zope-${ZOPE_VERSION}-final.tgz
+# [V] python.org keeps all historical releases
+ARG PYTHON_URL=https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz
+# [V] Verified 2026-08-19: Plone-2.1.4.tar.gz exists at dist.plone.org/archive/
+#     (the archive covers the whole tarball era: 2.0.x, 2.1.x, 2.5.x, 3.0.x)
+ARG PLONE_URL=https://dist.plone.org/archive/Plone-${PLONE_VERSION}.tar.gz
+# [V 2026-08-20] effbot.org is dead (404) and PyPI lists PIL but serves no
+# files; dist.plone.org/thirdparty is the surviving canonical source. Note this
+# is the Plone-community repackaging of PIL, not the stock effbot tarball.
+ARG PIL_URL=https://dist.plone.org/thirdparty/PIL-${PIL_VERSION}.tar.gz
+
+# --- simplejson -------------------------------------------------------------
+# Python has no stdlib `json` before 2.6, so every image below 4.0 ships
+# simplejson instead. The release is NOT interchangeable between interpreters
+# — see the header of shared/install-simplejson.sh, and note that the install
+# gate will fail the build on a wrong pairing rather than let it through.
+ARG SIMPLEJSON_VERSION=2.0.9
+ARG SIMPLEJSON_URL=https://files.pythonhosted.org/packages/source/s/simplejson/simplejson-${SIMPLEJSON_VERSION}.tar.gz
+
+# ---------------------------------------------------------------------------
+# Stage 1: fetch — modern TLS, nothing else
+# ---------------------------------------------------------------------------
+FROM debian:bookworm-slim AS fetch
+ARG ZOPE_URL
+ARG PYTHON_URL
+ARG PLONE_URL
+ARG PIL_URL
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates curl \
+ && rm -rf /var/lib/apt/lists/*
+WORKDIR /dist
+RUN curl -fSL "${PYTHON_URL}" -o python.tgz \
+ && curl -fSL "${ZOPE_URL}"   -o zope.tgz \
+ && curl -fSL "${PLONE_URL}"  -o plone.tar.gz \
+ && curl -fSL "${PIL_URL}"    -o pil.tar.gz
+
+# ---------------------------------------------------------------------------
+# Stage 1b: fetch-simplejson — derived from fetch, deliberately not part of it
+# ---------------------------------------------------------------------------
+# pybuild does `COPY --from=fetch /dist /dist`, so folding this download into
+# stage 1 would invalidate the interpreter build every time the simplejson pin
+# moves and recompile CPython from source — hours, under emulation on an arm64
+# host. Deriving a stage leaves `fetch` byte-identical, so pybuild stays cached,
+# and reuses the curl and ca-certificates already installed there. WORKDIR
+# /dist is inherited, so the tarball lands beside the others.
+FROM fetch AS fetch-simplejson
+ARG SIMPLEJSON_URL
+RUN curl -fSL --retry 5 --retry-delay 5 "${SIMPLEJSON_URL}" -o simplejson.tar.gz
+
+# ---------------------------------------------------------------------------
+# Stage 2a: pybuild — Python 2.4 only.
+# Split from the Zope stage so that `--target pybuild` is exactly gate G1:
+# a failure in Zope (G2) must not deny us a testable Python artifact.
+# ---------------------------------------------------------------------------
+FROM debian:bookworm AS pybuild
+ARG PYTHON_VERSION
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      gcc make libc6-dev zlib1g-dev libcrypt-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=fetch /dist /dist
+COPY shared/build-python2.sh /usr/local/bin/build-python2.sh
+
+# Gate G1: the script asserts `import zlib, sha, md5, crypt, socket, ...`.
+RUN build-python2.sh /dist/python.tgz "${PYTHON_VERSION}" /opt/python2.4
+
+# ---------------------------------------------------------------------------
+# Stage 2b: build — PIL, Zope 2.8, the Zope instance, and the Plone products.
+# ---------------------------------------------------------------------------
+FROM pybuild AS build
+ARG ZOPE_VERSION
+ARG PLONE_VERSION
+ARG PIL_VERSION
+
+# --- PIL --------------------------------------------------------------------
+# [V 2026-08-20] Required for Plone to load at all: CMFPlone/utils.py line 4 is
+# an unconditional `from PIL import Image`, and without it CMFPlone, Archetypes
+# and ATContentTypes all fail to import (decisions D2/D4).
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends libjpeg62-turbo-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY shared/build-pil.sh /usr/local/bin/build-pil.sh
+RUN build-pil.sh /dist/pil.tar.gz "${PIL_VERSION}" /opt/python2.4/bin/python2.4
+
+# --- Zope 2.8 ---------------------------------------------------------------
+# Zope 2.8 uses configure + make (distutils underneath). -fcommon avoids
+# gcc>=10 "multiple definition" errors from tentative definitions in the
+# old C extensions (ExtensionClass, cAccessControl, ZODB).
+RUN tar -xzf /dist/zope.tgz -C /tmp \
+ && cd /tmp/Zope-${ZOPE_VERSION}-final \
+ && ./configure --prefix=/opt/zope \
+      --with-python=/opt/python2.4/bin/python2.4 \
+ && CFLAGS="-fcommon -fno-strict-aliasing" make \
+ && make install \
+ && rm -rf /tmp/Zope-${ZOPE_VERSION}-final
+
+# --- Zope instance + Plone products -----------------------------------------
+# Placeholder inituser; the real one is written by the entrypoint at runtime.
+RUN /opt/python2.4/bin/python2.4 /opt/zope/bin/mkzopeinstance.py \
+      --dir /app/instance --user "admin:placeholder"
+
+# [V 2026-08-20] Bundle layout is Plone-2.1.4/<ProductName>/... (one dir per
+# product: CMFPlone, Archetypes, ATContentTypes, CMFQuickInstallerTool, ...),
+# confirmed with `tar -tzf`, so --strip-components=1 is correct.
+# Gate: `ls /app/instance/Products/CMFPlone/version.txt` succeeds.
+RUN mkdir -p /tmp/plone \
+ && tar -xzf /dist/plone.tar.gz -C /tmp/plone --strip-components=1 \
+ && cp -a /tmp/plone/. /app/instance/Products/ \
+ && test -d /app/instance/Products/CMFPlone \
+ && rm -rf /tmp/plone
+
+# Point the filestorage and logs at /data (populated at runtime).
+RUN sed -i \
+      -e 's|\$INSTANCE/var/Data.fs|/data/filestorage/Data.fs|' \
+      -e 's|\$INSTANCE/log|/data/log|' \
+      /app/instance/etc/zope.conf
+
+# --- simplejson -------------------------------------------------------------
+# Last in the stage, and with its ARG declared here rather than at the top, so
+# that moving the pin does not invalidate the PIL and Plone layers above.
+# site-packages lives under /opt/python2.4, which stage 3 copies wholesale, so
+# nothing further is needed at runtime.
+ARG SIMPLEJSON_VERSION
+COPY --from=fetch-simplejson /dist/simplejson.tar.gz /dist/simplejson.tar.gz
+COPY shared/install-simplejson.sh /usr/local/bin/install-simplejson.sh
+RUN install-simplejson.sh /dist/simplejson.tar.gz "${SIMPLEJSON_VERSION}" \
+      /opt/python2.4/bin/python2.4
+
+# ---------------------------------------------------------------------------
+# Stage 3: runtime
+# ---------------------------------------------------------------------------
+FROM debian:bookworm-slim
+ARG PLONE_VERSION
+ARG ZOPE_VERSION
+ARG PYTHON_VERSION
+
+LABEL org.opencontainers.image.title="Plone ${PLONE_VERSION} (legacy)" \
+      org.opencontainers.image.description="Plone ${PLONE_VERSION} on Zope ${ZOPE_VERSION} / Python ${PYTHON_VERSION}. Migration and content-extraction use only — NOT for production." \
+      org.opencontainers.image.vendor="Simples Consultoria"
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends zlib1g libcrypt1 libjpeg62-turbo \
+ && rm -rf /var/lib/apt/lists/* \
+ && useradd --system -m -d /app -U -u 500 plone \
+ && mkdir -p /data \
+ && chown -R plone:plone /data
+
+COPY --from=build --chown=plone:plone /opt/python2.4 /opt/python2.4
+COPY --from=build --chown=plone:plone /opt/zope /opt/zope
+COPY --from=build --chown=plone:plone /app /app
+COPY --chown=plone:plone shared/docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+COPY --chown=plone:plone shared/upgrade-plone.py /app/upgrade-plone.py
+COPY --chown=plone:plone shared/configure-zeo.sh /app/configure-zeo.sh
+RUN chmod +x /app/configure-zeo.sh
+
+ENV ZOPE_HOME=/opt/zope \
+    INSTANCE_HOME=/app/instance \
+    PYTHON=/opt/python2.4/bin/python2.4 \
+    ZOPE_HTTP_PORT=8080
+
+VOLUME /data
+EXPOSE 8080
+WORKDIR /app
+USER plone
+
+# ZServer is slow to warm up on first start (Data.fs creation + product init)
+HEALTHCHECK --interval=10s --timeout=5s --start-period=120s --retries=5 \
+  CMD ["/opt/python2.4/bin/python2.4", "-c", "import urllib; urllib.urlopen('http://127.0.0.1:8080/')"]
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["start"]

--- a/legacy/2.1/README.md
+++ b/legacy/2.1/README.md
@@ -1,0 +1,95 @@
+# Plone 2.1 legacy image
+
+Plone 2.1.4 on Zope 2.8.12 / Python 2.4.6. Tarball-era template (no buildout).
+
+**Not for production.** Zope 2.8 has known, unpatched vulnerabilities. This image
+exists for content extraction, migration rehearsal, and historical inspection.
+
+The image bundles **PIL 1.1.6** with JPEG and PNG support. This is not
+optional: `CMFPlone/utils.py` line 4 is an unconditional `from PIL import
+Image`, so without PIL, CMFPlone, Archetypes and ATContentTypes all fail to
+import and no Plone site can be created. All 30 bundled products register with
+no import or install errors, and a Plone site can be created end to end.
+
+## Usage
+
+```sh
+docker build -f 2.1/Dockerfile -t plone-legacy:2.1.4 .
+docker run -d -p 8080:8080 -e ADMIN_PASSWORD=secret \
+    -v plone21-data:/data plone-legacy:2.1.4
+```
+
+To mount an existing site, drop its `Data.fs` at `/data/filestorage/Data.fs`
+(and add its third-party products to `/app/instance/Products` via bind mount
+or a derived image).
+
+| | |
+|---|---|
+| Port | 8080 (`ZOPE_HTTP_PORT` to change) |
+| Volume | `/data` (`filestorage/Data.fs`, `log/`) |
+| User | `plone` (uid 500) |
+| Env | `ADMIN_USER`, `ADMIN_PASSWORD` (first run only) |
+| PIL | 1.1.6, with JPEG + PNG (no freetype/`_imagingft`) |
+
+## Validated facts / hypotheses
+
+- **[V]** `Zope-2.8.12-final.tgz` (last 2.8.x, 2010-01-12) is downloadable from
+  `old.zope.dev/Products/Zope/2.8.12/` — verified 2026-08-19.
+- **[V]** python.org serves all historical source releases, incl. 2.4.6.
+- **[V]** `Plone-2.1.4.tar.gz` (2006-09-19) is downloadable from
+  `dist.plone.org/archive/` — verified 2026-08-19. The same archive holds the
+  final tarballs for 2.0.5, 2.5.4, and 3.0.5, so it is the canonical fetch
+  source for the entire tarball era. (Supersedes H1, which assumed Launchpad.)
+- **[V 2026-08-20]** Python 2.4.6 compiles on bookworm (gcc 12 / glibc 2.36)
+  with the `posix_close` rename + `-fno-strict-aliasing -fwrapv` +
+  `--without-cxx` — **plus a multiarch patch that the original H2 missed.**
+  Python 2.4 predates Debian multiarch, so its `setup.py` looks for libraries in
+  `/usr/lib` while bookworm keeps `libz.so`/`libcrypt.so` only in
+  `/usr/lib/x86_64-linux-gnu`. Without the patch, zlib and crypt are silently
+  skipped and the gate fails with `ImportError: No module named zlib`. Note that
+  `LDFLAGS=-L...` does *not* help: setup.py only honours it on darwin.
+  *Gate:* `python2.4 -c "import zlib, sha, md5"` exits 0. **Passes**, with no
+  `*_failed.so` left in `lib-dynload`.
+- **[V 2026-08-28]** Bundle layout is `Plone-2.1.4/<Product>/...`, one directory
+  per product, confirmed with `tar -tzf`. **30** product directories land in
+  `Products/`; `CMFPlone/version.txt` reads `2.1.4`. Count directories, not
+  entries: `ls` reports 32 because `CONTENTS.txt` and `README.txt` sit
+  alongside the products and are not products.
+- **[V 2026-08-20]** Zope 2.8 C extensions compile with gcc 12 given
+  `CFLAGS="-fcommon -fno-strict-aliasing"`; `make install` succeeds in ~42 s and
+  `runzope` binds :8080. Not tested *without* `-fcommon`, so the flag is
+  confirmed sufficient, not proven necessary.
+- **[V 2026-08-20]** `zpasswd.py -u USER -p PASS FILE` writes a valid
+  `inituser`: `/manage_main` returns 200 under basic auth on a fresh volume.
+- **[V 2026-08-20]** `runzope` execs through to ZServer, so PID 1 is the Python
+  process itself. `docker stop` returns in 0.25 s with exit code 0.
+- **[V 2026-08-20]** CMFPlone 2.1.4 cannot be imported without PIL. Resolved by
+  bundling PIL 1.1.6 from `dist.plone.org/thirdparty/` — `effbot.org` is dead
+  (404) and PyPI lists PIL but serves no files, so that is the surviving
+  canonical source. Two traps: the tarball is repackaged for setuptools and
+  calls `ez_setup.use_setuptools()`, which cannot work because our Python 2.4
+  has no `_ssl` (fixed by dropping to distutils, *not* by bootstrapping
+  setuptools, which would reintroduce a network fetch); and PIL searches only
+  `/usr/local/lib` and `<prefix>/lib`, so libjpeg/libz go undetected and PIL
+  builds *successfully* without JPEG and PNG — fixed via the documented
+  `JPEG_ROOT`/`ZLIB_ROOT` hooks.
+- **[V 2026-08-20]** A Plone 2.1 site can be created and rendered: POST to
+  `manage_addProduct/CMFPlone/manage_addSite` (`id`, `title`,
+  `create_userfolder`) returns 302 and the site root serves ~23 kB carrying
+  `<meta name="generator" content="Plone - http://plone.org" />`.
+
+## Smoke test (CI gate)
+
+```sh
+make test-2.1                      # HTTP + auth + every product loads
+SMOKE_CREATE_SITE=1 make test-2.1  # also creates a Plone site and checks its markup
+```
+
+The product check is **fatal by default**; set `SMOKE_STRICT_PRODUCTS=0` to
+downgrade it to a warning. That default exists because Zope answers HTTP and
+authenticates perfectly well with every Plone product broken — the gate passed
+on an unusable image before this check was added.
+
+The `debian/eol:etch` fallback (period-correct gcc 4.1, with the fetch stage
+keeping old userland off the network) was **not needed**: strategy S1 reached
+gate G1 once the multiarch patch was added.

--- a/legacy/2.5/README.md
+++ b/legacy/2.5/README.md
@@ -53,7 +53,7 @@ or a derived image).
 - **[V 2026-08-20]** Python 2.4.6 builds via the shared `build-python2.sh`
   with no 2.5-specific changes; `lib-dynload` has no `*_failed.so`.
 - **[V 2026-08-20]** Bundle layout is `Plone-2.5.4-2/<Product>/...`, 38 product
-  directories (vs. 20 in 2.0.5 and 32 installed in 2.1.4).
+  directories (vs. 20 in 2.0.5 and 30 in 2.1.4).
 - **[V 2026-08-20]** Zope 2.9.12 C extensions compile with gcc 12 given
   `CFLAGS="-fcommon -fno-strict-aliasing"`. As with 2.8.12, this confirms the
   flag is *sufficient*; it was not re-run without `-fcommon`, so necessity is

--- a/legacy/Makefile
+++ b/legacy/Makefile
@@ -14,7 +14,7 @@ PLATFORM ?= linux/amd64
 # the matrix in README.md, and the ALL list in
 # ../.github/workflows/legacy-build.yml. One series lands per pull request;
 # append here as each one is ported.
-SERIES := 2.5 3.0 3.1 3.2 3.3 4.0 4.1 4.2
+SERIES := 2.1 2.5 3.0 3.1 3.2 3.3 4.0 4.1 4.2
 
 # Builder used for the -demo images, which MUST be a `docker`-driver one:
 # demo/Dockerfile's FROM reads the base image out of the local image store, and
@@ -42,6 +42,7 @@ DEMO_TEST_PASSWORD ?= smoke-not-admin
 # these images are built from.
 # [V 2026-08-20] 4.1.6 is both the final 4.1.x release and the last
 # UnifiedInstaller published for the series, so this row needs no compromise.
+FULL_VERSION_2.1 := 2.1.4
 # [V 2026-08-20] There is no Plone 2.5.5 on dist.plone.org (nor /download/
 # nor /packages/). The last 2.5.x is 2.5.4, shipped as two tarballs with
 # identical file lists; Plone-2.5.4-2.tar.gz is the later roll (adds the

--- a/legacy/README.md
+++ b/legacy/README.md
@@ -20,9 +20,10 @@ They exist for content extraction, migration rehearsal, and archaeology.
 | 3.1  | 3.1.7 | 2.10.6  | 2.4.6  | buildout | `simplejson` 2.0.9 (installed) | **done** |
 | 3.0  | 3.0.5 | 2.10.13 | 2.4.6  | tarball  | `simplejson` 2.0.9 (installed) | **done** |
 | 2.5  | 2.5.4-2 | 2.9.12  | 2.4.6  | tarball  | `simplejson` 2.0.9 (installed) | **done** |
+| 2.1  | 2.1.4 | 2.8.12  | 2.4.6  | tarball  | `simplejson` 2.0.9 (installed) | **done** |
 
 The matrix extends down to Plone 1.0. One series lands per pull request; the
-remaining three follow these.
+remaining two follow these.
 
 Adding a series touches eight places. Miss one and the build still passes — the
 image is simply never built, or the docs quietly disagree with what ships — so


### PR DESCRIPTION
Adds the Plone **2.1.4** image to the legacy matrix — Zope 2.8.12 / Python 2.4.6, tarball era.

Closes #195

No new shared scripts: the closure is the same one 2.5 uses — `build-python2.sh`, `build-pil.sh`, `install-simplejson.sh`, `docker-entrypoint.sh`, `upgrade-plone.py`, `configure-zeo.sh`.

## The older site factory

2.1 posts to a different endpoint than every ported series so far:

| Version | linked from `/manage_main` | form posts to |
|---|---|---|
| **2.1.4** | `CMFPlone/addSite` | `manage_addSite` |
| 2.5.4-2 | `addPloneSiteForm` | `addPloneSite` |

`shared/smoke-test.sh` resolved `addSite -> manage_addSite` on its own, with no change. That is now the **second** independent series to exercise the run-time discovery added during the 2.5 port — the version-agnostic gate is holding up.

## The multiarch patch matters here

Python 2.4 predates Debian multiarch, so its `setup.py` looks in `/usr/lib` while bookworm keeps `libz` and `libcrypt` only in `/usr/lib/x86_64-linux-gnu`. Without the patch `build-python2.sh` carries, zlib and crypt are skipped **silently** and the interpreter comes out unusable. Verified on the built image: `import zlib, sha, md5` exits 0.

## Two wrong product counts, corrected rather than copied forward

The port convention is a verbatim copy from `plone-legacy`, but the ledger's whole purpose is to be the *verified* record, so these are fixed here.

**`32 products land in Products/`** → the image has **30 product directories**. `ls` reports 32 because `CONTENTS.txt` and `README.txt` sit alongside the products and are not products. The bullet now gives the directory count, says which number `ls` reports, and says why — so the entry count cannot quietly come back.

This was one step from happening in the 2.5 port too, where the README's `38` happened to be a genuine directory count and survived checking.

**`All 37 products register`** → not reproducible from the image at all. It is not the 30 bundle directories, not the 32 entries, and not 30 + Zope's 22 built-in products (which would be 52, and double-counts `BTreeFolder2`). Rather than substitute another guess, the sentence now states what the smoke gate actually proves: all 30 register with no import or install errors.

`legacy/2.5/README.md` carried the bad figure in its cross-reference — *"vs. 20 in 2.0.5 and 32 installed in 2.1.4"* — so that is corrected in the same commit. Its other two figures were checked and **are** right: 2.5.4-2 has 38 product directories and 2.0.5 has 20, both directory counts.

## Verification

- `make lint` — 10 Dockerfiles, 11 shell scripts, workflow YAML
- `make -n` on all four 2.1 targets, including the `test-demo-2.1` case the GNU Make 3.81 stem rule would otherwise route to `test-%`
- `SMOKE_CREATE_SITE=1 make test-2.1` — **6/6**, site root 23630 bytes
- `make test-demo-2.1` — **6/6**, build-time password confirmed dead after the `ADMIN_PASSWORD` reset

Versions read **out of the built image**, not from the `ARG`s: `Products/CMFPlone/version.txt` → `2.1.4`, interpreter → `2.4.6`, simplejson 2.0.9 imports, `from PIL import Image` succeeds.

## Note on CI

The base build was fully cache-hit from the `plone-legacy` checkout, so the cold build — CPython 2.4.6, PIL and Zope 2.8.12 all compiled from source — is exercised for the first time in this PR's CI run. The `-demo` layer did rebuild locally, seed step included.

Two series remain after this one: #196 (2.0) and #197 (1.0).
