### PR TITLE
Add the Plone 2.0 legacy image

### DIFF
--- a/.github/workflows/legacy-build.yml
+++ b/.github/workflows/legacy-build.yml
@@ -37,6 +37,9 @@ jobs:
               - 'legacy/demo/**'
               - 'legacy/Makefile'
               - '.github/workflows/legacy-build.yml'
+            v2.0:
+              - *shared
+              - 'legacy/2.0/**'
             v2.1:
               - *shared
               - 'legacy/2.1/**'
@@ -73,7 +76,7 @@ jobs:
           BUILD_ALL: ${{ github.event_name != 'pull_request' }}
         run: |
           # Implemented versions; append when a new directory lands.
-          ALL='["2.1","2.5","3.0","3.1","3.2","3.3","4.0","4.1","4.2"]'
+          ALL='["2.0","2.1","2.5","3.0","3.1","3.2","3.3","4.0","4.1","4.2"]'
           if [ "${BUILD_ALL}" = "true" ]; then
             VERSIONS="${ALL}"
           else

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -1,4 +1,6 @@
 # Changelog
+- Add Plone 2.0 image to the legacy matrix. Refs #196
+  [@ericof]
 - Add Plone 2.1 image to the legacy matrix. Refs #195
   [@ericof]
 - Add Plone 2.5 image to the legacy matrix. Refs #194

--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ listed; earlier point releases remain in the repository and on Docker Hub.
 | 3.0.5 | 2.4.6 | Debian *(legacy)* | [`legacy/3.0/Dockerfile`](legacy/3.0/Dockerfile) | `3.0`, `3.0.5`, `3.0-demo`, `3.0.5-demo` |
 | 2.5.4-2 | 2.4.6 | Debian *(legacy)* | [`legacy/2.5/Dockerfile`](legacy/2.5/Dockerfile) | `2.5`, `2.5.4-2`, `2.5-demo`, `2.5.4-2-demo` |
 | 2.1.4 | 2.4.6 | Debian *(legacy)* | [`legacy/2.1/Dockerfile`](legacy/2.1/Dockerfile) | `2.1`, `2.1.4`, `2.1-demo`, `2.1.4-demo` |
+| 2.0.5 | 2.3.7 | Debian *(legacy)* | [`legacy/2.0/Dockerfile`](legacy/2.0/Dockerfile) | `2.0`, `2.0.5`, `2.0-demo`, `2.0.5-demo` |
 
 ### Where the tags live
 

--- a/legacy/2.0/Dockerfile
+++ b/legacy/2.0/Dockerfile
@@ -1,0 +1,206 @@
+# syntax=docker/dockerfile:1
+#
+# Plone 2.0.x — tarball era (Zope 2.7.x / Python 2.3.x)
+#
+# The oldest image in the matrix. Strategy:
+#   Stage 1 (fetch): modern userland downloads everything (old TLS never touches network)
+#   Stage 2 (build): compile Python 2.3 + PIL + Zope 2.7 on bookworm (gcc 12: warns, doesn't error)
+#   Stage 3 (runtime): slim image, non-root, /data volume, port 8080
+#
+# The Python and PIL builds live in shared/build-python2.sh and
+# shared/build-pil.sh, which every tarball-era image uses.
+#
+# NOT FOR PRODUCTION. Zope 2.7 has known, unpatched security issues.
+# Intended for content extraction, migration, and archaeology only.
+
+# [V 2026-08-20] Zope 2.7.8's ./configure declares TARGET="2.3.5" and
+# ACCEPTABLE="2.3.4 2.3.3", which does NOT list 2.3.7 — but that list is only
+# consulted by get_python(), the $PATH search. Passing --with-python=<path>
+# sets FOUND directly and skips get_python() entirely, and inst/configure.py
+# (the real configurator) gates only on pyexpat, zlib and large-file support,
+# never on sys.version. So 2.3.7 is accepted. It is preferred over the
+# declared 2.3.5 target because it is the last 2.3.x (2008) and carries four
+# more years of fixes toward building on a modern toolchain; 2.3.x is stable
+# within the series, so Zope's C extensions are unaffected.
+# [V 2026-08-20] 2.3.7 bundles expat (Modules/expat/) and defines
+# HAVE_LARGEFILE_SUPPORT, so both of Zope's hard gates are satisfiable.
+ARG PYTHON_VERSION=2.3.7
+ARG ZOPE_VERSION=2.7.8
+ARG PLONE_VERSION=2.0.5
+# [V 2026-08-20] Unlike 2.1.4 and 2.5.4, Plone 2.0.5 does NOT require PIL:
+# CMFPlone never imports it, and the single use site guards itself —
+#   Archetypes/Field.py:964  try: import PIL.Image / except: has_pil=None
+# It is bundled anyway (Érico's call, 2026-08-20) so image scaling actually
+# works rather than silently degrading during a migration rehearsal, and so
+# all three tarball-era images have the same shape.
+ARG PIL_VERSION=1.1.6
+
+# [V 2026-08-20] Verified: Zope-2.7.8-final.tgz (2.9 MB) exists at old.zope.dev
+# and unpacks to Zope-2.7.8-final/ with a top-level ./configure.
+ARG ZOPE_URL=https://old.zope.dev/Products/Zope/${ZOPE_VERSION}/Zope-${ZOPE_VERSION}-final.tgz
+# [V] python.org keeps all historical releases
+ARG PYTHON_URL=https://www.python.org/ftp/python/${PYTHON_VERSION}/Python-${PYTHON_VERSION}.tgz
+# [V 2026-08-20] Verified: Plone-2.0.5.tar.gz (4.2 MB, 2004-12-01) exists at
+# dist.plone.org/archive/ and is the last 2.0.x (only RCs follow it).
+ARG PLONE_URL=https://dist.plone.org/archive/Plone-${PLONE_VERSION}.tar.gz
+# [V 2026-08-20] effbot.org is dead (404) and PyPI lists PIL but serves no
+# files; dist.plone.org/thirdparty is the surviving canonical source.
+ARG PIL_URL=https://dist.plone.org/thirdparty/PIL-${PIL_VERSION}.tar.gz
+
+# --- simplejson -------------------------------------------------------------
+# Python has no stdlib `json` before 2.6, so every image below 4.0 ships
+# simplejson instead. The release is NOT interchangeable between interpreters
+# — see the header of shared/install-simplejson.sh, and note that the install
+# gate will fail the build on a wrong pairing rather than let it through.
+ARG SIMPLEJSON_VERSION=1.9.3
+ARG SIMPLEJSON_URL=https://files.pythonhosted.org/packages/source/s/simplejson/simplejson-${SIMPLEJSON_VERSION}.tar.gz
+
+# ---------------------------------------------------------------------------
+# Stage 1: fetch — modern TLS, nothing else
+# ---------------------------------------------------------------------------
+FROM debian:bookworm-slim AS fetch
+ARG ZOPE_URL
+ARG PYTHON_URL
+ARG PLONE_URL
+ARG PIL_URL
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends ca-certificates curl \
+ && rm -rf /var/lib/apt/lists/*
+WORKDIR /dist
+RUN curl -fSL "${PYTHON_URL}" -o python.tgz \
+ && curl -fSL "${ZOPE_URL}"   -o zope.tgz \
+ && curl -fSL "${PLONE_URL}"  -o plone.tar.gz \
+ && curl -fSL "${PIL_URL}"    -o pil.tar.gz
+
+# ---------------------------------------------------------------------------
+# Stage 1b: fetch-simplejson — derived from fetch, deliberately not part of it
+# ---------------------------------------------------------------------------
+# pybuild does `COPY --from=fetch /dist /dist`, so folding this download into
+# stage 1 would invalidate the interpreter build every time the simplejson pin
+# moves and recompile CPython from source — hours, under emulation on an arm64
+# host. Deriving a stage leaves `fetch` byte-identical, so pybuild stays cached,
+# and reuses the curl and ca-certificates already installed there. WORKDIR
+# /dist is inherited, so the tarball lands beside the others.
+FROM fetch AS fetch-simplejson
+ARG SIMPLEJSON_URL
+RUN curl -fSL --retry 5 --retry-delay 5 "${SIMPLEJSON_URL}" -o simplejson.tar.gz
+
+# ---------------------------------------------------------------------------
+# Stage 2a: pybuild — Python 2.3 only, so `--target pybuild` is exactly gate G1
+# and a Zope failure cannot deny us a testable interpreter.
+# ---------------------------------------------------------------------------
+FROM debian:bookworm AS pybuild
+ARG PYTHON_VERSION
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends \
+      gcc make libc6-dev zlib1g-dev libcrypt-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY --from=fetch /dist /dist
+COPY shared/build-python2.sh /usr/local/bin/build-python2.sh
+
+RUN build-python2.sh /dist/python.tgz "${PYTHON_VERSION}" /opt/python2.3
+
+# ---------------------------------------------------------------------------
+# Stage 2b: build — PIL, Zope 2.7, the Zope instance, and the Plone products.
+# ---------------------------------------------------------------------------
+FROM pybuild AS build
+ARG ZOPE_VERSION
+ARG PLONE_VERSION
+ARG PIL_VERSION
+
+# --- PIL --------------------------------------------------------------------
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends libjpeg62-turbo-dev \
+ && rm -rf /var/lib/apt/lists/*
+
+COPY shared/build-pil.sh /usr/local/bin/build-pil.sh
+RUN build-pil.sh /dist/pil.tar.gz "${PIL_VERSION}" /opt/python2.3/bin/python2.3
+
+# --- Zope 2.7 ---------------------------------------------------------------
+# Oldest C in the matrix: this is the pre-rewrite ExtensionClass. -fcommon
+# avoids gcc>=10 "multiple definition" errors from tentative definitions.
+RUN tar -xzf /dist/zope.tgz -C /tmp \
+ && cd /tmp/Zope-${ZOPE_VERSION}-final \
+ && ./configure --prefix=/opt/zope \
+      --with-python=/opt/python2.3/bin/python2.3 \
+ && CFLAGS="-fcommon -fno-strict-aliasing" make \
+ && make install \
+ && rm -rf /tmp/Zope-${ZOPE_VERSION}-final
+
+# --- Zope instance + Plone products -----------------------------------------
+# Placeholder inituser; the real one is written by the entrypoint at runtime.
+RUN /opt/python2.3/bin/python2.3 /opt/zope/bin/mkzopeinstance.py \
+      --dir /app/instance --user "admin:placeholder"
+
+# [V 2026-08-20] Bundle layout is Plone-2.0.5/<ProductName>/..., 20 product
+# directories, confirmed with `tar -tzf` — same shape as 2.1.4 and 2.5.4-2,
+# so --strip-components=1 is correct.
+RUN mkdir -p /tmp/plone \
+ && tar -xzf /dist/plone.tar.gz -C /tmp/plone --strip-components=1 \
+ && cp -a /tmp/plone/. /app/instance/Products/ \
+ && test -d /app/instance/Products/CMFPlone \
+ && rm -rf /tmp/plone
+
+# Point the filestorage and logs at /data (populated at runtime).
+RUN sed -i \
+      -e 's|\$INSTANCE/var/Data.fs|/data/filestorage/Data.fs|' \
+      -e 's|\$INSTANCE/log|/data/log|' \
+      /app/instance/etc/zope.conf
+
+# --- simplejson -------------------------------------------------------------
+# Last in the stage, and with its ARG declared here rather than at the top, so
+# that moving the pin does not invalidate the PIL and Plone layers above.
+# site-packages lives under /opt/python2.3, which stage 3 copies wholesale, so
+# nothing further is needed at runtime.
+ARG SIMPLEJSON_VERSION
+COPY --from=fetch-simplejson /dist/simplejson.tar.gz /dist/simplejson.tar.gz
+COPY shared/install-simplejson.sh /usr/local/bin/install-simplejson.sh
+RUN install-simplejson.sh /dist/simplejson.tar.gz "${SIMPLEJSON_VERSION}" \
+      /opt/python2.3/bin/python2.3
+
+# ---------------------------------------------------------------------------
+# Stage 3: runtime
+# ---------------------------------------------------------------------------
+FROM debian:bookworm-slim
+ARG PLONE_VERSION
+ARG ZOPE_VERSION
+ARG PYTHON_VERSION
+
+LABEL org.opencontainers.image.title="Plone ${PLONE_VERSION} (legacy)" \
+      org.opencontainers.image.description="Plone ${PLONE_VERSION} on Zope ${ZOPE_VERSION} / Python ${PYTHON_VERSION}. Migration and content-extraction use only — NOT for production." \
+      org.opencontainers.image.vendor="Simples Consultoria"
+
+RUN apt-get update \
+ && apt-get install -y --no-install-recommends zlib1g libcrypt1 libjpeg62-turbo \
+ && rm -rf /var/lib/apt/lists/* \
+ && useradd --system -m -d /app -U -u 500 plone \
+ && mkdir -p /data \
+ && chown -R plone:plone /data
+
+COPY --from=build --chown=plone:plone /opt/python2.3 /opt/python2.3
+COPY --from=build --chown=plone:plone /opt/zope /opt/zope
+COPY --from=build --chown=plone:plone /app /app
+COPY --chown=plone:plone shared/docker-entrypoint.sh /docker-entrypoint.sh
+RUN chmod +x /docker-entrypoint.sh
+COPY --chown=plone:plone shared/upgrade-plone.py /app/upgrade-plone.py
+COPY --chown=plone:plone shared/configure-zeo.sh /app/configure-zeo.sh
+RUN chmod +x /app/configure-zeo.sh
+
+ENV ZOPE_HOME=/opt/zope \
+    INSTANCE_HOME=/app/instance \
+    PYTHON=/opt/python2.3/bin/python2.3 \
+    ZOPE_HTTP_PORT=8080
+
+VOLUME /data
+EXPOSE 8080
+WORKDIR /app
+USER plone
+
+# ZServer is slow to warm up on first start (Data.fs creation + product init)
+HEALTHCHECK --interval=10s --timeout=5s --start-period=120s --retries=5 \
+  CMD ["/opt/python2.3/bin/python2.3", "-c", "import urllib; urllib.urlopen('http://127.0.0.1:8080/')"]
+
+ENTRYPOINT ["/docker-entrypoint.sh"]
+CMD ["start"]

--- a/legacy/2.0/README.md
+++ b/legacy/2.0/README.md
@@ -1,0 +1,106 @@
+# Plone 2.0 legacy image
+
+Plone 2.0.5 on Zope 2.7.8 / Python 2.3.7. Tarball-era template (no buildout).
+The oldest image in the matrix.
+
+**Not for production.** Zope 2.7 has known, unpatched vulnerabilities. This image
+exists for content extraction, migration rehearsal, and historical inspection.
+
+## Usage
+
+```sh
+docker build -f 2.0/Dockerfile -t plone-legacy:2.0.5 .
+docker run -d -p 8080:8080 -e ADMIN_PASSWORD=secret \
+    -v plone20-data:/data plone-legacy:2.0.5
+```
+
+To mount an existing site, drop its `Data.fs` at `/data/filestorage/Data.fs`
+(and add its third-party products to `/app/instance/Products` via bind mount
+or a derived image).
+
+| | |
+|---|---|
+| Port | 8080 (`ZOPE_HTTP_PORT` to change) |
+| FTP | 8021, **not** `EXPOSE`d — publish with `-p 8021:8021` if wanted |
+| Volume | `/data` (`filestorage/Data.fs`, `log/`) |
+| User | `plone` (uid 500) |
+| Env | `ADMIN_USER`, `ADMIN_PASSWORD` (first run only) |
+| PIL | 1.1.6, with JPEG + PNG (no freetype/`_imagingft`) |
+
+### The FTP server
+
+Unlike 2.8 and 2.9, Zope 2.7's `mkzopeinstance` writes an **uncommented
+`<ftp-server>` block** alongside the HTTP one. It is left enabled here, since
+FTP is a genuinely convenient way to pull content out of an old site:
+
+```sh
+docker run -d -p 8080:8080 -p 8021:8021 -e ADMIN_PASSWORD=secret plone-legacy:2.0.5
+```
+
+## Validated facts / hypotheses
+
+- **[V 2026-08-20]** **S1 was sufficient — the period-toolchain fallback (S3,
+  `debian/eol:etch`) was NOT needed.** The prior guidance was to assume S3 from
+  the start for 2.0 because Zope 2.7 carries the pre-rewrite ExtensionClass,
+  the oldest C in the matrix. In the event, Python 2.3.7 *and* Zope 2.7.8 both
+  built on bookworm/gcc 12 with exactly the same mitigations as 2.1 and 2.5,
+  via the shared `build-python2.sh` with no 2.0-specific changes.
+- **[V 2026-08-20]** **Python 2.3.7 is accepted despite not being on Zope's
+  list.** Zope 2.7.8's `./configure` declares `TARGET="2.3.5"` and
+  `ACCEPTABLE="2.3.4 2.3.3"`. That list is only consulted by `get_python()`,
+  the `$PATH` search: `--with-python=<path>` assigns `FOUND` directly and skips
+  it. The real configurator, `inst/configure.py`, gates on **pyexpat, zlib and
+  large-file support** and never inspects `sys.version`. Verified by reading
+  both scripts before building, then confirmed by the build.
+- **[V 2026-08-20]** All three of those gates pass on 2.3.7:
+  `zlib 1.2.13`, `expat 1.95.7` (bundled in `Modules/expat/`), and
+  `f.seek(2147483649L)` succeeds.
+- **[V 2026-08-20]** The generalised multiarch patch was **load-bearing here**.
+  Python 2.3.7 writes `lib_dirs` on one line —
+  `lib_dirs = self.compiler.library_dirs + ['/lib', '/usr/lib']` — where 2.4.6
+  uses a multi-line list, so 2.1's original literal pattern would have matched
+  zero times and failed its own `grep -c` guard. `build-python2.sh` anchors on
+  `self.compiler.library_dirs + [` instead, which holds for both.
+- **[V 2026-08-20]** `lib-dynload` contains no `*_failed.so`. `nismodule.c`'s
+  `rpc/rpc.h` error is the documented benign one (optional module, skipped).
+- **[V 2026-08-20]** Gate G2: `ExtensionClass`, `Acquisition` and
+  `BTrees.OOBTree` all import from the installed Zope 2.7.8 tree.
+- **[V 2026-08-20]** **Bug found and fixed in the shared entrypoint.** The
+  first 2.0 container exited immediately:
+
+  ```
+  ZConfig.ConfigurationError: There was a problem starting a server of type
+  "FTPServer" ... (Address already in use)
+  ```
+
+  Cause: `docker-entrypoint.sh` templated `ZOPE_HTTP_PORT` with an unscoped
+  `s|address N|address $PORT|`, which rewrote **every** `address` line. Zope 2.7
+  emits two server blocks, so the FTP server was pointed at 8080 as well and
+  Zope died binding the port twice. Zope 2.8/2.9 emit only `<http-server>`,
+  which is why this stayed latent through 2.1 and 2.5. The sed is now confined
+  to the `<http-server>` block by a range address. 2.1 and 2.5 were rebuilt and
+  re-tested after the fix, with unchanged results.
+- **[V 2026-08-20]** With the fix, `zope.conf` keeps `address 8080` under
+  `<http-server>` and `address 8021` under `<ftp-server>`, and the FTP service
+  answers: `220 ... FTP server (Medusa Async V1.23 [experimental]) ready.`
+- **[V 2026-08-20]** **PIL is optional in 2.0.5, unlike 2.1.4 and 2.5.4.**
+  CMFPlone never imports it; the only use site is guarded —
+  `Archetypes/Field.py:964` does `try: import PIL.Image / except: has_pil=None`
+  ("no PIL, no scaled versions!"). It is bundled anyway by decision, so scaling
+  works and all three tarball-era images have the same shape.
+- **[V 2026-08-20]** Bundle layout is `Plone-2.0.5/<Product>/...`, 20 product
+  directories (22 entries land in `Products/` counting the two loose text
+  files). Zero products fail to import or install.
+- **[V 2026-08-20]** The site factory matches 2.1, not 2.5:
+  `/manage_main` links `CMFPlone/addSite`, whose form posts to
+  `manage_addSite`. The smoke test discovers this rather than assuming it.
+- **[V 2026-08-20]** A Plone 2.0 site can be created and rendered: the site
+  root serves ~27 kB carrying the Plone `generator` meta tag — the largest of
+  the three, since 2.0 inlines more of its markup.
+
+## Smoke test (CI gate)
+
+```sh
+make test-2.0                      # HTTP + auth + every product loads
+SMOKE_CREATE_SITE=1 make test-2.0  # also creates a Plone site and checks its markup
+```

--- a/legacy/Makefile
+++ b/legacy/Makefile
@@ -14,7 +14,7 @@ PLATFORM ?= linux/amd64
 # the matrix in README.md, and the ALL list in
 # ../.github/workflows/legacy-build.yml. One series lands per pull request;
 # append here as each one is ported.
-SERIES := 2.1 2.5 3.0 3.1 3.2 3.3 4.0 4.1 4.2
+SERIES := 2.0 2.1 2.5 3.0 3.1 3.2 3.3 4.0 4.1 4.2
 
 # Builder used for the -demo images, which MUST be a `docker`-driver one:
 # demo/Dockerfile's FROM reads the base image out of the local image store, and
@@ -42,6 +42,7 @@ DEMO_TEST_PASSWORD ?= smoke-not-admin
 # these images are built from.
 # [V 2026-08-20] 4.1.6 is both the final 4.1.x release and the last
 # UnifiedInstaller published for the series, so this row needs no compromise.
+FULL_VERSION_2.0 := 2.0.5
 FULL_VERSION_2.1 := 2.1.4
 # [V 2026-08-20] There is no Plone 2.5.5 on dist.plone.org (nor /download/
 # nor /packages/). The last 2.5.x is 2.5.4, shipped as two tarballs with

--- a/legacy/README.md
+++ b/legacy/README.md
@@ -21,9 +21,10 @@ They exist for content extraction, migration rehearsal, and archaeology.
 | 3.0  | 3.0.5 | 2.10.13 | 2.4.6  | tarball  | `simplejson` 2.0.9 (installed) | **done** |
 | 2.5  | 2.5.4-2 | 2.9.12  | 2.4.6  | tarball  | `simplejson` 2.0.9 (installed) | **done** |
 | 2.1  | 2.1.4 | 2.8.12  | 2.4.6  | tarball  | `simplejson` 2.0.9 (installed) | **done** |
+| 2.0  | 2.0.5 | 2.7.8   | 2.3.7  | tarball  | `simplejson` 1.9.3 (installed) | **done** |
 
 The matrix extends down to Plone 1.0. One series lands per pull request; the
-remaining two follow these.
+remaining one follows these.
 
 Adding a series touches eight places. Miss one and the build still passes — the
 image is simply never built, or the docs quietly disagree with what ships — so
@@ -116,10 +117,18 @@ are applied to the seeded database before Zope starts serving, since Zope's own
 ## JSON
 
 Python grew a stdlib `json` in 2.6, so the 4.x series need nothing extra. Every
-series below 4.0 ships `simplejson` 2.0.9 instead — 3.3 finds it already in its
-own buildout-cache, while 3.2 and earlier have it installed by
-`shared/install-simplejson.sh`. Import defensively if one script must cover the
-whole matrix:
+series below 4.0 ships `simplejson` instead — 3.3 finds it already in its own
+buildout-cache, while 3.2 and earlier have it installed by
+`shared/install-simplejson.sh`.
+
+**The release is not the same across the matrix, and cannot be.** 2.4-era
+series get 2.0.9; Plone 2.0 runs on Python 2.3, where 2.0.9's `encoder.py`
+calls `items.sort(key=...)` — `key=` is 2.4+ — so `dumps(sort_keys=True)`
+raises `TypeError`. That series gets 1.9.3. `install-simplejson.sh` fails the
+build on a wrong pairing rather than shipping an image whose JSON breaks only
+on the call that matters for extraction.
+
+Import defensively if one script must cover the whole matrix:
 
 ```python
 try:


### PR DESCRIPTION
Adds the Plone **2.0.5** image to the legacy matrix — Zope 2.7.8 / Python 2.3.7, tarball era.

Closes #196

No new shared scripts: the closure is the one 2.1 and 2.5 already use.

## simplejson is 1.9.3 here, not 2.0.9

On Python 2.3, simplejson 2.0.9's `encoder.py` calls `items.sort(key=...)` — and `key=` is 2.4+ — so `dumps(sort_keys=True)` raises `TypeError`.

The failure lands precisely on the call that content extraction cares about, and nowhere else. That is what makes it worth pinning rather than discovering later, on someone's migration. `install-simplejson.sh` already gates the pairing and fails the build on a wrong one.

Verified on the built image, not inferred:

```
simplejson.__version__                        → 1.9.3
dumps({"b": 1, "a": 2}, sort_keys=True)       → {"a": 2, "b": 1}
```

### This makes the JSON section in `legacy/README.md` wrong as written

It stated that *"Every series below 4.0 ships `simplejson` 2.0.9"* — true right up to this commit. It now describes the split (2.0.9 for the 2.4-era series, 1.9.3 for 2.0) and the reason, so the next reader does not learn a rule the matrix has stopped following.

That is a **ninth** place touched, beyond the eight the checklist names. The checklist covers the *wiring*; it does not cover prose that a new series happens to falsify.

## Python 2.3.7 vs Zope's acceptable list

Zope 2.7.8's `./configure` declares `TARGET="2.3.5"` and `ACCEPTABLE="2.3.4 2.3.3"`, which reads like 2.3.7 should be rejected. It isn't: that list is consulted only by `get_python()`, the `$PATH` search. `--with-python=<path>` assigns `FOUND` directly and skips it, and the real configurator gates on **pyexpat, zlib and large-file support** without ever inspecting `sys.version`.

## The FTP server, and the latent bug it already exposed

2.7's `mkzopeinstance` writes an **uncommented `<ftp-server>` block** alongside the HTTP one — unlike 2.8 and 2.9, which emit only `<http-server>`. It is left enabled, since FTP is a genuinely convenient way to pull content out of an old site.

The shared entrypoint already carries the fix this exposed: the `ZOPE_HTTP_PORT` substitution is confined to the `<http-server>` block by a range address. An unscoped `sed` once rewrote the FTP port to 8080 as well and killed Zope on a double bind — latent through 2.1 and 2.5 because neither emits a second server block.

## Counts needed no correction this time

Unlike 2.1, `2.0/README.md` already states **20 product directories**, and notes that 22 entries land in `Products/` counting the two loose text files. Confirmed against the image. So 2.1 was the outlier, not the rule.

## Verification

- `make lint` — 11 Dockerfiles, 11 shell scripts, workflow YAML
- `make -n` on all four 2.0 targets, including the `test-demo-2.0` case the GNU Make 3.81 stem rule would otherwise route to `test-%`
- `SMOKE_CREATE_SITE=1 make test-2.0` — **6/6**, site root 27213 bytes (the largest of the tarball era; 2.0 inlines more of its markup)
- `make test-demo-2.0` — **6/6**, build-time password confirmed dead after the `ADMIN_PASSWORD` reset

Versions read **out of the built image**: `Products/CMFPlone/version.txt` → `2.0.5`, interpreter → `2.3.7`, 20 product directories.

## Notes

Both builds were cache-hit from the `plone-legacy` checkout, so the cold build — CPython 2.3.7, PIL and Zope 2.7.8 all compiled from source — is exercised for the first time in this PR's CI run.

`legacy/2.0/README.md` opens with *"The oldest image in the matrix."* That is accurate today and stops being accurate when #197 lands 1.0, so it is left alone here and belongs on that port's checklist.

One series remains: #197 (1.0).
